### PR TITLE
debug

### DIFF
--- a/COMMON/OglImage.cpp
+++ b/COMMON/OglImage.cpp
@@ -143,17 +143,17 @@ void t_FillHole3D(OglImage3D& v)
 
 void t_Erode3D(const EVec3i& reso, byte* vol)
 {
-  t_Erode3D(reso[0], reso[1], reso[1], vol);
+  t_Erode3D(reso[0], reso[1], reso[2], vol);
 }
 
 void t_Dilate3D(const EVec3i& reso, byte* vol)
 {
-  t_Dilate3D(reso[0], reso[1], reso[1], vol);
+  t_Dilate3D(reso[0], reso[1], reso[2], vol);
 }
 
 void t_FillHole3D(const EVec3i& reso, byte* vol)
 {
-  t_FillHole3D(reso[0], reso[1], reso[1], vol);
+  t_FillHole3D(reso[0], reso[1], reso[2], vol);
 }
 
 

--- a/COMMON/OglImage.h
+++ b/COMMON/OglImage.h
@@ -571,7 +571,7 @@ void t_Sobel3D(const int W, const int H, const int D, const T1* vol, T2* res)
     if (z == 0 || z == D - 1) gz = 0;
     res[i] = (T2)sqrt(gx * gx + gy * gy + gz * gz) / 16.0f;
 
-    if (res[i] > 40000) std::cout << x << " " << y << " " << z << "\n";
+    //if (res[i] > 40000) std::cout << x << " " << y << " " << z << "\n";
   }
 }
 

--- a/RoiPainter3D/RoiPainter3D/FormVisMask.cpp
+++ b/RoiPainter3D/RoiPainter3D/FormVisMask.cpp
@@ -125,13 +125,6 @@ System::Void FormVisMask::trackbar_alpha_Scroll (
 }
 
 
-static void updateImageCoreVisVolumes()
-{
-  const EVec2i minmax = ImageCore::GetInst()->GetVolMinMax();
-  ImageCore::GetInst()->UpdateOGLVolume(minmax[0], minmax[1]);
-}
-
-
 //DELETE/MARGE/
 System::Void FormVisMask::btnDelete_Click(
     System::Object^  sender, 
@@ -139,8 +132,6 @@ System::Void FormVisMask::btnDelete_Click(
 {
   ImageCore::GetInst()->ActiveMask_Delete();
   updateList();
-
-  updateImageCoreVisVolumes();
   RedrawScene();
 }
 
@@ -166,7 +157,6 @@ System::Void FormVisMask::btnMargeTo_Click(
   ImageCore::GetInst()->MargeMaskIDs(trgt_ids);
   
   updateList();
-  updateImageCoreVisVolumes();
   RedrawScene();
 }
 
@@ -178,7 +168,6 @@ System::Void FormVisMask::btnErode_Click(
     System::EventArgs^  e)
 {
   ImageCore::GetInst()->ActiveMask_Erode();
-  updateImageCoreVisVolumes();
   updateList();
   RedrawScene();
 }
@@ -190,7 +179,6 @@ System::Void FormVisMask::btnDilate_Click(
     System::EventArgs^  e)
 {
   ImageCore::GetInst()->ActiveMask_Dilate();
-  updateImageCoreVisVolumes();
   updateList();
   RedrawScene();
 }
@@ -216,7 +204,6 @@ System::Void FormVisMask::btnFillHole_Click(
   }
 
   ImageCore::GetInst()->FillHole( trgt_ids );
-  updateImageCoreVisVolumes();
   updateList();
   RedrawScene();
 }
@@ -275,7 +262,6 @@ System::Void FormVisMask::btnSmartFillHole_Click(
 
   ImageCore::GetInst()->SmartFillHole(trgt_ids, dilation_size);
   updateList();
-  updateImageCoreVisVolumes();
   RedrawScene();
 }
 


### PR DESCRIPTION
+ vis mask modeで dilation/erosion/fillhole できないバグを修正
+ 微分値が大きすぎる場合にデバッグ表示がされる部分を削除
+ vis mask modeで、編集の度にwindow levelが初期化されるバグを修正