### PR TITLE
Dev UI cleanup

### DIFF
--- a/COMMON/DeformationStrokes.cpp
+++ b/COMMON/DeformationStrokes.cpp
@@ -5,7 +5,7 @@
 #include <fstream>
 
 
-bool PlanarCurve::AddCP(const EVec3f &pos, int& inserted_idx)
+bool PlanarCurve::AddCP(const EVec3f &pos, int& inserted_idx, const EVec3f& mesh_normal)
 {
   const int num_cps = static_cast<int>(m_cps.size());
 
@@ -18,6 +18,22 @@ bool PlanarCurve::AddCP(const EVec3f &pos, int& inserted_idx)
   {
     std::cout << "strange input at AddCP\n";
     return false;
+  }
+
+  if (num_cps == 1 && mesh_normal.norm() > 0.001f)
+  {
+    EVec3f tangent = (pos - m_cps[0]).normalized();
+    EVec3f plane_normal = GetCrssecNorm();
+    EVec3f curve_normal = plane_normal.cross(tangent).normalized();
+
+    if (curve_normal.dot(mesh_normal) < 0.0f)
+    {
+      m_normal_side = false;
+    }
+    else
+    {
+      m_normal_side = true;
+    }
   }
 
   if ( num_cps <= 2 )

--- a/COMMON/DeformationStrokes.cpp
+++ b/COMMON/DeformationStrokes.cpp
@@ -5,7 +5,21 @@
 #include <fstream>
 
 
-bool PlanarCurve::AddCP(const EVec3f &pos, int& inserted_idx, const EVec3f& mesh_normal)
+
+void PlanarCurve::AlignNormalWithMesh(const EVec3f& mesh_normal)
+{
+  if (m_cps.size() < 2 || mesh_normal.norm() <= 0.001f) return;
+  EVec3f tangent = (m_cps[1] - m_cps[0]).normalized();
+  EVec3f plane_normal = GetCrssecNorm();
+  EVec3f curve_normal = plane_normal.cross(tangent).normalized();
+
+  if (curve_normal.dot(mesh_normal) < 0.0f) m_normal_side = false;
+  else m_normal_side = true;
+}
+
+
+
+bool PlanarCurve::AddCP(const EVec3f &pos, int& inserted_idx)
 {
   const int num_cps = static_cast<int>(m_cps.size());
 
@@ -18,22 +32,6 @@ bool PlanarCurve::AddCP(const EVec3f &pos, int& inserted_idx, const EVec3f& mesh
   {
     std::cout << "strange input at AddCP\n";
     return false;
-  }
-
-  if (num_cps == 1 && mesh_normal.norm() > 0.001f)
-  {
-    EVec3f tangent = (pos - m_cps[0]).normalized();
-    EVec3f plane_normal = GetCrssecNorm();
-    EVec3f curve_normal = plane_normal.cross(tangent).normalized();
-
-    if (curve_normal.dot(mesh_normal) < 0.0f)
-    {
-      m_normal_side = false;
-    }
-    else
-    {
-      m_normal_side = true;
-    }
   }
 
   if ( num_cps <= 2 )

--- a/COMMON/DeformationStrokes.h
+++ b/COMMON/DeformationStrokes.h
@@ -49,9 +49,10 @@ public:
 
   inline bool GetNormalSide() const { return m_normal_side; }
   inline void FlipNormal() { m_normal_side = !m_normal_side; }
+  void AlignNormalWithMesh(const EVec3f& mesh_normal);
 
   //CP manipulation
-  bool AddCP(const EVec3f& pos, int& inserted_idx, const EVec3f& mesh_normal = EVec3f(0.0f, 0.0f, 0.0f)); // return inserted cp idx
+  bool AddCP(const EVec3f& pos, int& inserted_idx); // return inserted cp idx
   void MoveCP(int cpidx, const EVec3f& _pos);
   void DeleteCP(int cpidx);
   bool PickCPs(const EVec3f& ray_pos, const EVec3f& ray_dir, const float cp_radius, int& cpidx, EVec3f& cp_pos) const;

--- a/COMMON/DeformationStrokes.h
+++ b/COMMON/DeformationStrokes.h
@@ -51,7 +51,7 @@ public:
   inline void FlipNormal() { m_normal_side = !m_normal_side; }
 
   //CP manipulation
-  bool AddCP(const EVec3f& pos, int& inserted_idx); // return inserted cp idx
+  bool AddCP(const EVec3f& pos, int& inserted_idx, const EVec3f& mesh_normal = EVec3f(0.0f, 0.0f, 0.0f)); // return inserted cp idx
   void MoveCP(int cpidx, const EVec3f& _pos);
   void DeleteCP(int cpidx);
   bool PickCPs(const EVec3f& ray_pos, const EVec3f& ray_dir, const float cp_radius, int& cpidx, EVec3f& cp_pos) const;

--- a/RoiPainter4D/RoiPainter4D/FormRefCurveDeform.h
+++ b/RoiPainter4D/RoiPainter4D/FormRefCurveDeform.h
@@ -68,7 +68,8 @@ namespace RoiPainter4D {
   private: System::Windows::Forms::Button^ m_btn_deform_all;
   private: System::Windows::Forms::Button^ m_btn_cancel;
   private: System::Windows::Forms::Button^ m_btn_finish;
-  
+  private: System::Windows::Forms::GroupBox^ groupBox1;
+
   
   
   private:
@@ -105,17 +106,19 @@ namespace RoiPainter4D {
       this->m_btn_deform_all = (gcnew System::Windows::Forms::Button());
       this->m_btn_cancel = (gcnew System::Windows::Forms::Button());
       this->m_btn_finish = (gcnew System::Windows::Forms::Button());
+      this->groupBox1 = (gcnew System::Windows::Forms::GroupBox());
       (cli::safe_cast<System::ComponentModel::ISupportInitialize^>(this->m_numbox_cpsize))->BeginInit();
       (cli::safe_cast<System::ComponentModel::ISupportInitialize^>(this->m_trackbar_mcstride))->BeginInit();
+      this->groupBox1->SuspendLayout();
       this->SuspendLayout();
       // 
       // m_btn_genmesh
       // 
       this->m_btn_genmesh->Font = (gcnew System::Drawing::Font(L"MS UI Gothic", 9, System::Drawing::FontStyle::Regular, System::Drawing::GraphicsUnit::Point,
-    	static_cast<System::Byte>(128)));
+        static_cast<System::Byte>(128)));
       this->m_btn_genmesh->Location = System::Drawing::Point(8, 10);
       this->m_btn_genmesh->Name = L"m_btn_genmesh";
-      this->m_btn_genmesh->Size = System::Drawing::Size(135, 23);
+      this->m_btn_genmesh->Size = System::Drawing::Size(137, 26);
       this->m_btn_genmesh->TabIndex = 0;
       this->m_btn_genmesh->Text = L"Create Mesh Models";
       this->m_btn_genmesh->UseVisualStyleBackColor = true;
@@ -123,9 +126,9 @@ namespace RoiPainter4D {
       // 
       // m_btn_deform
       // 
-      this->m_btn_deform->Location = System::Drawing::Point(4, 252);
+      this->m_btn_deform->Location = System::Drawing::Point(6, 18);
       this->m_btn_deform->Name = L"m_btn_deform";
-      this->m_btn_deform->Size = System::Drawing::Size(135, 32);
+      this->m_btn_deform->Size = System::Drawing::Size(138, 36);
       this->m_btn_deform->TabIndex = 1;
       this->m_btn_deform->Text = L"Deform Current Frame";
       this->m_btn_deform->UseVisualStyleBackColor = true;
@@ -133,9 +136,9 @@ namespace RoiPainter4D {
       // 
       // m_btn_undo
       // 
-      this->m_btn_undo->Location = System::Drawing::Point(28, 187);
+      this->m_btn_undo->Location = System::Drawing::Point(156, 302);
       this->m_btn_undo->Name = L"m_btn_undo";
-      this->m_btn_undo->Size = System::Drawing::Size(89, 23);
+      this->m_btn_undo->Size = System::Drawing::Size(137, 26);
       this->m_btn_undo->TabIndex = 2;
       this->m_btn_undo->Text = L"UNDO";
       this->m_btn_undo->UseVisualStyleBackColor = true;
@@ -143,28 +146,28 @@ namespace RoiPainter4D {
       // 
       // m_btn_copy_from_preframe
       // 
-      this->m_btn_copy_from_preframe->Location = System::Drawing::Point(153, 118);
+      this->m_btn_copy_from_preframe->Location = System::Drawing::Point(6, 95);
       this->m_btn_copy_from_preframe->Name = L"m_btn_copy_from_preframe";
-      this->m_btn_copy_from_preframe->Size = System::Drawing::Size(142, 36);
+      this->m_btn_copy_from_preframe->Size = System::Drawing::Size(138, 36);
       this->m_btn_copy_from_preframe->TabIndex = 1;
-      this->m_btn_copy_from_preframe->Text = L"Copy curves from prev frame";
+      this->m_btn_copy_from_preframe->Text = L"Copy curves from pre_frame";
       this->m_btn_copy_from_preframe->UseVisualStyleBackColor = true;
       this->m_btn_copy_from_preframe->Click += gcnew System::EventHandler(this, &FormRefCurveDeform::m_btn_copy_from_preframe_Click);
       // 
       // m_btn_copy_to_allframe
       // 
-      this->m_btn_copy_to_allframe->Location = System::Drawing::Point(153, 160);
+      this->m_btn_copy_to_allframe->Location = System::Drawing::Point(145, 56);
       this->m_btn_copy_to_allframe->Name = L"m_btn_copy_to_allframe";
-      this->m_btn_copy_to_allframe->Size = System::Drawing::Size(142, 36);
+      this->m_btn_copy_to_allframe->Size = System::Drawing::Size(135, 36);
       this->m_btn_copy_to_allframe->TabIndex = 1;
-      this->m_btn_copy_to_allframe->Text = L"Copy curves in this fame to all frame";
+      this->m_btn_copy_to_allframe->Text = L"Copy curves in this frame to all frame";
       this->m_btn_copy_to_allframe->UseVisualStyleBackColor = true;
       this->m_btn_copy_to_allframe->Click += gcnew System::EventHandler(this, &FormRefCurveDeform::m_btn_copy_to_allframe_Click);
       // 
       // m_numbox_cpsize
       // 
       this->m_numbox_cpsize->Font = (gcnew System::Drawing::Font(L"MS UI Gothic", 11.5F));
-      this->m_numbox_cpsize->Location = System::Drawing::Point(69, 81);
+      this->m_numbox_cpsize->Location = System::Drawing::Point(69, 67);
       this->m_numbox_cpsize->Minimum = System::Decimal(gcnew cli::array< System::Int32 >(4) { 1, 0, 0, 0 });
       this->m_numbox_cpsize->Name = L"m_numbox_cpsize";
       this->m_numbox_cpsize->Size = System::Drawing::Size(57, 23);
@@ -177,7 +180,7 @@ namespace RoiPainter4D {
       // 
       this->m_cb_only_select_curve->AutoSize = true;
       this->m_cb_only_select_curve->Font = (gcnew System::Drawing::Font(L"MS UI Gothic", 8));
-      this->m_cb_only_select_curve->Location = System::Drawing::Point(147, 85);
+      this->m_cb_only_select_curve->Location = System::Drawing::Point(6, 179);
       this->m_cb_only_select_curve->Name = L"m_cb_only_select_curve";
       this->m_cb_only_select_curve->Size = System::Drawing::Size(148, 15);
       this->m_cb_only_select_curve->TabIndex = 27;
@@ -188,18 +191,18 @@ namespace RoiPainter4D {
       // m_trackbar_mcstride
       // 
       this->m_trackbar_mcstride->LargeChange = 1;
-      this->m_trackbar_mcstride->Location = System::Drawing::Point(147, 10);
+      this->m_trackbar_mcstride->Location = System::Drawing::Point(153, 12);
       this->m_trackbar_mcstride->Maximum = 4;
       this->m_trackbar_mcstride->Minimum = 1;
       this->m_trackbar_mcstride->Name = L"m_trackbar_mcstride";
-      this->m_trackbar_mcstride->Size = System::Drawing::Size(139, 45);
+      this->m_trackbar_mcstride->Size = System::Drawing::Size(140, 45);
       this->m_trackbar_mcstride->TabIndex = 28;
       this->m_trackbar_mcstride->Value = 2;
       // 
       // label1
       // 
       this->label1->AutoSize = true;
-      this->label1->Location = System::Drawing::Point(152, 43);
+      this->label1->Location = System::Drawing::Point(160, 45);
       this->label1->Name = L"label1";
       this->label1->Size = System::Drawing::Size(17, 12);
       this->label1->TabIndex = 29;
@@ -208,7 +211,7 @@ namespace RoiPainter4D {
       // label2
       // 
       this->label2->AutoSize = true;
-      this->label2->Location = System::Drawing::Point(190, 43);
+      this->label2->Location = System::Drawing::Point(197, 45);
       this->label2->Name = L"label2";
       this->label2->Size = System::Drawing::Size(17, 12);
       this->label2->TabIndex = 29;
@@ -217,7 +220,7 @@ namespace RoiPainter4D {
       // label3
       // 
       this->label3->AutoSize = true;
-      this->label3->Location = System::Drawing::Point(228, 43);
+      this->label3->Location = System::Drawing::Point(233, 45);
       this->label3->Name = L"label3";
       this->label3->Size = System::Drawing::Size(17, 12);
       this->label3->TabIndex = 29;
@@ -226,7 +229,7 @@ namespace RoiPainter4D {
       // label4
       // 
       this->label4->AutoSize = true;
-      this->label4->Location = System::Drawing::Point(17, 85);
+      this->label4->Location = System::Drawing::Point(17, 72);
       this->label4->Name = L"label4";
       this->label4->Size = System::Drawing::Size(46, 12);
       this->label4->TabIndex = 26;
@@ -235,7 +238,7 @@ namespace RoiPainter4D {
       // label5
       // 
       this->label5->AutoSize = true;
-      this->label5->Location = System::Drawing::Point(265, 43);
+      this->label5->Location = System::Drawing::Point(271, 45);
       this->label5->Name = L"label5";
       this->label5->Size = System::Drawing::Size(17, 12);
       this->label5->TabIndex = 29;
@@ -244,10 +247,10 @@ namespace RoiPainter4D {
       // m_btn_reload_mesh
       // 
       this->m_btn_reload_mesh->Font = (gcnew System::Drawing::Font(L"MS UI Gothic", 9, System::Drawing::FontStyle::Regular, System::Drawing::GraphicsUnit::Point,
-    	static_cast<System::Byte>(128)));
+        static_cast<System::Byte>(128)));
       this->m_btn_reload_mesh->Location = System::Drawing::Point(8, 38);
       this->m_btn_reload_mesh->Name = L"m_btn_reload_mesh";
-      this->m_btn_reload_mesh->Size = System::Drawing::Size(135, 23);
+      this->m_btn_reload_mesh->Size = System::Drawing::Size(137, 26);
       this->m_btn_reload_mesh->TabIndex = 0;
       this->m_btn_reload_mesh->Text = L"Reload mesh";
       this->m_btn_reload_mesh->UseVisualStyleBackColor = true;
@@ -255,9 +258,9 @@ namespace RoiPainter4D {
       // 
       // m_btn_sharestroke
       // 
-      this->m_btn_sharestroke->Location = System::Drawing::Point(6, 129);
+      this->m_btn_sharestroke->Location = System::Drawing::Point(6, 56);
       this->m_btn_sharestroke->Name = L"m_btn_sharestroke";
-      this->m_btn_sharestroke->Size = System::Drawing::Size(133, 23);
+      this->m_btn_sharestroke->Size = System::Drawing::Size(138, 36);
       this->m_btn_sharestroke->TabIndex = 1;
       this->m_btn_sharestroke->Text = L"Set as all frame curve";
       this->m_btn_sharestroke->UseVisualStyleBackColor = true;
@@ -265,9 +268,9 @@ namespace RoiPainter4D {
       // 
       // m_btn_loadstate
       // 
-      this->m_btn_loadstate->Location = System::Drawing::Point(153, 202);
+      this->m_btn_loadstate->Location = System::Drawing::Point(8, 334);
       this->m_btn_loadstate->Name = L"m_btn_loadstate";
-      this->m_btn_loadstate->Size = System::Drawing::Size(68, 32);
+      this->m_btn_loadstate->Size = System::Drawing::Size(137, 26);
       this->m_btn_loadstate->TabIndex = 1;
       this->m_btn_loadstate->Text = L"Load state";
       this->m_btn_loadstate->UseVisualStyleBackColor = true;
@@ -275,9 +278,9 @@ namespace RoiPainter4D {
       // 
       // m_btn_savestate
       // 
-      this->m_btn_savestate->Location = System::Drawing::Point(227, 202);
+      this->m_btn_savestate->Location = System::Drawing::Point(8, 302);
       this->m_btn_savestate->Name = L"m_btn_savestate";
-      this->m_btn_savestate->Size = System::Drawing::Size(68, 32);
+      this->m_btn_savestate->Size = System::Drawing::Size(137, 26);
       this->m_btn_savestate->TabIndex = 1;
       this->m_btn_savestate->Text = L"Save state";
       this->m_btn_savestate->UseVisualStyleBackColor = true;
@@ -285,9 +288,9 @@ namespace RoiPainter4D {
       // 
       // m_btn_flipnormal
       // 
-      this->m_btn_flipnormal->Location = System::Drawing::Point(6, 158);
+      this->m_btn_flipnormal->Location = System::Drawing::Point(6, 137);
       this->m_btn_flipnormal->Name = L"m_btn_flipnormal";
-      this->m_btn_flipnormal->Size = System::Drawing::Size(133, 23);
+      this->m_btn_flipnormal->Size = System::Drawing::Size(138, 36);
       this->m_btn_flipnormal->TabIndex = 30;
       this->m_btn_flipnormal->Text = L"flip normals";
       this->m_btn_flipnormal->UseVisualStyleBackColor = true;
@@ -295,67 +298,79 @@ namespace RoiPainter4D {
       // 
       // m_btn_deform_all
       // 
-      this->m_btn_deform_all->Location = System::Drawing::Point(154, 252);
+      this->m_btn_deform_all->Location = System::Drawing::Point(145, 18);
       this->m_btn_deform_all->Name = L"m_btn_deform_all";
-      this->m_btn_deform_all->Size = System::Drawing::Size(135, 32);
+      this->m_btn_deform_all->Size = System::Drawing::Size(135, 36);
       this->m_btn_deform_all->TabIndex = 31;
       this->m_btn_deform_all->Text = L"Deform All Frame";
       this->m_btn_deform_all->UseVisualStyleBackColor = true;
       this->m_btn_deform_all->Click += gcnew System::EventHandler(this, &FormRefCurveDeform::m_btn_deform_all_Click);
       // 
-      // m_cancel
+      // m_btn_cancel
       // 
-      this->m_btn_cancel->Location = System::Drawing::Point(46, 309);
-      this->m_btn_cancel->Name = L"m_cancel";
-      this->m_btn_cancel->Size = System::Drawing::Size(93, 32);
+      this->m_btn_cancel->Location = System::Drawing::Point(8, 365);
+      this->m_btn_cancel->Name = L"m_btn_cancel";
+      this->m_btn_cancel->Size = System::Drawing::Size(137, 26);
       this->m_btn_cancel->TabIndex = 32;
       this->m_btn_cancel->Text = L"Cancel";
       this->m_btn_cancel->UseVisualStyleBackColor = true;
       this->m_btn_cancel->Click += gcnew System::EventHandler(this, &FormRefCurveDeform::m_cancel_Click);
       // 
-      // m_finish
+      // m_btn_finish
       // 
-      this->m_btn_finish->Location = System::Drawing::Point(154, 309);
-      this->m_btn_finish->Name = L"m_finish";
-      this->m_btn_finish->Size = System::Drawing::Size(135, 32);
+      this->m_btn_finish->Location = System::Drawing::Point(158, 365);
+      this->m_btn_finish->Name = L"m_btn_finish";
+      this->m_btn_finish->Size = System::Drawing::Size(135, 26);
       this->m_btn_finish->TabIndex = 33;
       this->m_btn_finish->Text = L"Finish Segmentation";
       this->m_btn_finish->UseVisualStyleBackColor = true;
       this->m_btn_finish->Click += gcnew System::EventHandler(this, &FormRefCurveDeform::m_finish_Click);
+      // 
+      // groupBox1
+      // 
+      this->groupBox1->Controls->Add(this->m_btn_sharestroke);
+      this->groupBox1->Controls->Add(this->m_btn_copy_from_preframe);
+      this->groupBox1->Controls->Add(this->m_btn_flipnormal);
+      this->groupBox1->Controls->Add(this->m_btn_deform_all);
+      this->groupBox1->Controls->Add(this->m_btn_deform);
+      this->groupBox1->Controls->Add(this->m_cb_only_select_curve);
+      this->groupBox1->Controls->Add(this->m_btn_copy_to_allframe);
+      this->groupBox1->Location = System::Drawing::Point(8, 96);
+      this->groupBox1->Name = L"groupBox1";
+      this->groupBox1->Size = System::Drawing::Size(285, 200);
+      this->groupBox1->TabIndex = 34;
+      this->groupBox1->TabStop = false;
+      this->groupBox1->Text = L"Stroke ＆ Deformation";
       // 
       // FormRefCurveDeform
       // 
       this->AutoScaleDimensions = System::Drawing::SizeF(6, 12);
       this->AutoScaleMode = System::Windows::Forms::AutoScaleMode::Font;
       this->ClientSize = System::Drawing::Size(300, 397);
+      this->Controls->Add(this->groupBox1);
       this->Controls->Add(this->m_btn_finish);
+      this->Controls->Add(this->m_btn_undo);
       this->Controls->Add(this->m_btn_cancel);
-      this->Controls->Add(this->m_btn_deform_all);
-      this->Controls->Add(this->m_btn_flipnormal);
       this->Controls->Add(this->label5);
       this->Controls->Add(this->label3);
+      this->Controls->Add(this->m_btn_loadstate);
       this->Controls->Add(this->label2);
+      this->Controls->Add(this->m_btn_savestate);
       this->Controls->Add(this->label1);
       this->Controls->Add(this->m_trackbar_mcstride);
-      this->Controls->Add(this->m_cb_only_select_curve);
       this->Controls->Add(this->label4);
       this->Controls->Add(this->m_numbox_cpsize);
-      this->Controls->Add(this->m_btn_undo);
-      this->Controls->Add(this->m_btn_copy_to_allframe);
-      this->Controls->Add(this->m_btn_sharestroke);
-      this->Controls->Add(this->m_btn_savestate);
-      this->Controls->Add(this->m_btn_loadstate);
-      this->Controls->Add(this->m_btn_copy_from_preframe);
-      this->Controls->Add(this->m_btn_deform);
       this->Controls->Add(this->m_btn_reload_mesh);
       this->Controls->Add(this->m_btn_genmesh);
       this->Name = L"FormRefCurveDeform";
       this->Text = L"RefCurveDeform";
       (cli::safe_cast<System::ComponentModel::ISupportInitialize^>(this->m_numbox_cpsize))->EndInit();
       (cli::safe_cast<System::ComponentModel::ISupportInitialize^>(this->m_trackbar_mcstride))->EndInit();
+      this->groupBox1->ResumeLayout(false);
+      this->groupBox1->PerformLayout();
       this->ResumeLayout(false);
       this->PerformLayout();
-    
+
     }
 #pragma endregion
 	private:

--- a/RoiPainter4D/RoiPainter4D/FormRefCurveDeform.h
+++ b/RoiPainter4D/RoiPainter4D/FormRefCurveDeform.h
@@ -2,18 +2,18 @@
 
 namespace RoiPainter4D {
 
-	using namespace System;
-	using namespace System::ComponentModel;
-	using namespace System::Collections;
-	using namespace System::Windows::Forms;
-	using namespace System::Data;
-	using namespace System::Drawing;
+  using namespace System;
+  using namespace System::ComponentModel;
+  using namespace System::Collections;
+  using namespace System::Windows::Forms;
+  using namespace System::Data;
+  using namespace System::Drawing;
 
-	/// <summary>
-	/// FormRefCurveDeform の概要
-	/// </summary>
-	public ref class FormRefCurveDeform : public System::Windows::Forms::Form
-	{
+  /// <summary>
+  /// FormRefCurveDeform の概要
+  /// </summary>
+  public ref class FormRefCurveDeform : public System::Windows::Forms::Form
+  {
   private:
     static FormRefCurveDeform^ m_singleton;
     FormRefCurveDeform(void)
@@ -32,361 +32,359 @@ namespace RoiPainter4D {
 
     void InitAllItems();
 
-	protected:
-		/// <summary>
-		/// 使用中のリソースをすべてクリーンアップします。
-		/// </summary>
-		~FormRefCurveDeform()
-		{
-			if (components)
-			{
-				delete components;
-			}
-		}
-	private: System::Windows::Forms::NumericUpDown^ m_numbox_cpsize;
-	private: System::Windows::Forms::TrackBar^ m_trackbar_mcstride;
-
-	private: System::Windows::Forms::Label^ label1;
-	private: System::Windows::Forms::Label^ label2;
-	private: System::Windows::Forms::Label^ label3;
-	private: System::Windows::Forms::Label^ label4;
-	private: System::Windows::Forms::Label^ label5;
-
-	private: System::Windows::Forms::Button^ m_btn_reload_mesh;
-	private: System::Windows::Forms::Button^ m_btn_sharestroke;
-	private: System::Windows::Forms::Button^ m_btn_loadstate;
-	private: System::Windows::Forms::Button^ m_btn_savestate;
-	private: System::Windows::Forms::Button^ m_btn_flipnormal;
-	private: System::Windows::Forms::Button^ m_btn_genmesh;
-	private: System::Windows::Forms::Button^ m_btn_deform;
-	private: System::Windows::Forms::Button^ m_btn_undo;
-
-	private: System::Windows::Forms::Button^ m_btn_copy_from_preframe;
-	private: System::Windows::Forms::Button^ m_btn_copy_to_allframe;
-
-	private: System::Windows::Forms::CheckBox^ m_cb_only_select_curve;
-	private: System::Windows::Forms::Button^ m_btn_deform_all;
-	private: System::Windows::Forms::Button^ m_cancel;
-	private: System::Windows::Forms::Button^ m_finish;
-
-
-
-
-
-	private:
-		/// <summary>
-		/// 必要なデザイナー変数です。
-		/// </summary>
-		System::ComponentModel::Container ^components;
+  protected:
+  	/// <summary>
+  	/// 使用中のリソースをすべてクリーンアップします。
+  	/// </summary>
+  	~FormRefCurveDeform()
+  	{
+  		if (components)
+  		{
+  			delete components;
+  		}
+  	}
+  private: System::Windows::Forms::NumericUpDown^ m_numbox_cpsize;
+  private: System::Windows::Forms::TrackBar^ m_trackbar_mcstride;
+  
+  private: System::Windows::Forms::Label^ label1;
+  private: System::Windows::Forms::Label^ label2;
+  private: System::Windows::Forms::Label^ label3;
+  private: System::Windows::Forms::Label^ label4;
+  private: System::Windows::Forms::Label^ label5;
+  
+  private: System::Windows::Forms::Button^ m_btn_reload_mesh;
+  private: System::Windows::Forms::Button^ m_btn_sharestroke;
+  private: System::Windows::Forms::Button^ m_btn_loadstate;
+  private: System::Windows::Forms::Button^ m_btn_savestate;
+  private: System::Windows::Forms::Button^ m_btn_flipnormal;
+  private: System::Windows::Forms::Button^ m_btn_genmesh;
+  private: System::Windows::Forms::Button^ m_btn_deform;
+  private: System::Windows::Forms::Button^ m_btn_undo;
+  
+  private: System::Windows::Forms::Button^ m_btn_copy_from_preframe;
+  private: System::Windows::Forms::Button^ m_btn_copy_to_allframe;
+  
+  private: System::Windows::Forms::CheckBox^ m_cb_only_select_curve;
+  private: System::Windows::Forms::Button^ m_btn_deform_all;
+  private: System::Windows::Forms::Button^ m_btn_cancel;
+  private: System::Windows::Forms::Button^ m_btn_finish;
+  
+  
+  
+  private:
+  	/// <summary>
+  	/// 必要なデザイナー変数です。
+  	/// </summary>
+  	System::ComponentModel::Container ^components;
 
 #pragma region Windows Form Designer generated code
-		/// <summary>
-		/// デザイナー サポートに必要なメソッドです。このメソッドの内容を
-		/// コード エディターで変更しないでください。
-		/// </summary>
-		void InitializeComponent(void)
-		{
-			this->m_btn_genmesh = (gcnew System::Windows::Forms::Button());
-			this->m_btn_deform = (gcnew System::Windows::Forms::Button());
-			this->m_btn_undo = (gcnew System::Windows::Forms::Button());
-			this->m_btn_copy_from_preframe = (gcnew System::Windows::Forms::Button());
-			this->m_btn_copy_to_allframe = (gcnew System::Windows::Forms::Button());
-			this->m_numbox_cpsize = (gcnew System::Windows::Forms::NumericUpDown());
-			this->m_cb_only_select_curve = (gcnew System::Windows::Forms::CheckBox());
-			this->m_trackbar_mcstride = (gcnew System::Windows::Forms::TrackBar());
-			this->label1 = (gcnew System::Windows::Forms::Label());
-			this->label2 = (gcnew System::Windows::Forms::Label());
-			this->label3 = (gcnew System::Windows::Forms::Label());
-			this->label4 = (gcnew System::Windows::Forms::Label());
-			this->label5 = (gcnew System::Windows::Forms::Label());
-			this->m_btn_reload_mesh = (gcnew System::Windows::Forms::Button());
-			this->m_btn_sharestroke = (gcnew System::Windows::Forms::Button());
-			this->m_btn_loadstate = (gcnew System::Windows::Forms::Button());
-			this->m_btn_savestate = (gcnew System::Windows::Forms::Button());
-			this->m_btn_flipnormal = (gcnew System::Windows::Forms::Button());
-			this->m_btn_deform_all = (gcnew System::Windows::Forms::Button());
-			this->m_cancel = (gcnew System::Windows::Forms::Button());
-			this->m_finish = (gcnew System::Windows::Forms::Button());
-			(cli::safe_cast<System::ComponentModel::ISupportInitialize^>(this->m_numbox_cpsize))->BeginInit();
-			(cli::safe_cast<System::ComponentModel::ISupportInitialize^>(this->m_trackbar_mcstride))->BeginInit();
-			this->SuspendLayout();
-			// 
-			// m_btn_genmesh
-			// 
-			this->m_btn_genmesh->Font = (gcnew System::Drawing::Font(L"MS UI Gothic", 9, System::Drawing::FontStyle::Regular, System::Drawing::GraphicsUnit::Point,
-				static_cast<System::Byte>(128)));
-			this->m_btn_genmesh->Location = System::Drawing::Point(8, 10);
-			this->m_btn_genmesh->Name = L"m_btn_genmesh";
-			this->m_btn_genmesh->Size = System::Drawing::Size(135, 23);
-			this->m_btn_genmesh->TabIndex = 0;
-			this->m_btn_genmesh->Text = L"Create Mesh Models";
-			this->m_btn_genmesh->UseVisualStyleBackColor = true;
-			this->m_btn_genmesh->Click += gcnew System::EventHandler(this, &FormRefCurveDeform::m_btn_genmesh_Click);
-			// 
-			// m_btn_deform
-			// 
-			this->m_btn_deform->Location = System::Drawing::Point(4, 252);
-			this->m_btn_deform->Name = L"m_btn_deform";
-			this->m_btn_deform->Size = System::Drawing::Size(135, 32);
-			this->m_btn_deform->TabIndex = 1;
-			this->m_btn_deform->Text = L"Deform Current Frame";
-			this->m_btn_deform->UseVisualStyleBackColor = true;
-			this->m_btn_deform->Click += gcnew System::EventHandler(this, &FormRefCurveDeform::m_btn_deform_Click);
-			// 
-			// m_btn_undo
-			// 
-			this->m_btn_undo->Location = System::Drawing::Point(28, 187);
-			this->m_btn_undo->Name = L"m_btn_undo";
-			this->m_btn_undo->Size = System::Drawing::Size(89, 23);
-			this->m_btn_undo->TabIndex = 2;
-			this->m_btn_undo->Text = L"UNDO";
-			this->m_btn_undo->UseVisualStyleBackColor = true;
-			this->m_btn_undo->Click += gcnew System::EventHandler(this, &FormRefCurveDeform::m_btn_undo_Click);
-			// 
-			// m_btn_copy_from_preframe
-			// 
-			this->m_btn_copy_from_preframe->Location = System::Drawing::Point(153, 118);
-			this->m_btn_copy_from_preframe->Name = L"m_btn_copy_from_preframe";
-			this->m_btn_copy_from_preframe->Size = System::Drawing::Size(142, 36);
-			this->m_btn_copy_from_preframe->TabIndex = 1;
-			this->m_btn_copy_from_preframe->Text = L"Copy curves from prev frame";
-			this->m_btn_copy_from_preframe->UseVisualStyleBackColor = true;
-			this->m_btn_copy_from_preframe->Click += gcnew System::EventHandler(this, &FormRefCurveDeform::m_btn_copy_from_preframe_Click);
-			// 
-			// m_btn_copy_to_allframe
-			// 
-			this->m_btn_copy_to_allframe->Location = System::Drawing::Point(153, 160);
-			this->m_btn_copy_to_allframe->Name = L"m_btn_copy_to_allframe";
-			this->m_btn_copy_to_allframe->Size = System::Drawing::Size(142, 36);
-			this->m_btn_copy_to_allframe->TabIndex = 1;
-			this->m_btn_copy_to_allframe->Text = L"Copy curves in this fame to all frame";
-			this->m_btn_copy_to_allframe->UseVisualStyleBackColor = true;
-			this->m_btn_copy_to_allframe->Click += gcnew System::EventHandler(this, &FormRefCurveDeform::m_btn_copy_to_allframe_Click);
-			// 
-			// m_numbox_cpsize
-			// 
-			this->m_numbox_cpsize->Font = (gcnew System::Drawing::Font(L"MS UI Gothic", 11.5F));
-			this->m_numbox_cpsize->Location = System::Drawing::Point(69, 81);
-			this->m_numbox_cpsize->Minimum = System::Decimal(gcnew cli::array< System::Int32 >(4) { 1, 0, 0, 0 });
-			this->m_numbox_cpsize->Name = L"m_numbox_cpsize";
-			this->m_numbox_cpsize->Size = System::Drawing::Size(57, 23);
-			this->m_numbox_cpsize->TabIndex = 25;
-			this->m_numbox_cpsize->TextAlign = System::Windows::Forms::HorizontalAlignment::Right;
-			this->m_numbox_cpsize->Value = System::Decimal(gcnew cli::array< System::Int32 >(4) { 10, 0, 0, 0 });
-			this->m_numbox_cpsize->ValueChanged += gcnew System::EventHandler(this, &FormRefCurveDeform::m_numbox_cpsize_ValueChanged);
-			// 
-			// m_cb_only_select_curve
-			// 
-			this->m_cb_only_select_curve->AutoSize = true;
-			this->m_cb_only_select_curve->Font = (gcnew System::Drawing::Font(L"MS UI Gothic", 8));
-			this->m_cb_only_select_curve->Location = System::Drawing::Point(147, 85);
-			this->m_cb_only_select_curve->Name = L"m_cb_only_select_curve";
-			this->m_cb_only_select_curve->Size = System::Drawing::Size(148, 15);
-			this->m_cb_only_select_curve->TabIndex = 27;
-			this->m_cb_only_select_curve->Text = L"Show only selected stroke";
-			this->m_cb_only_select_curve->UseVisualStyleBackColor = true;
-			this->m_cb_only_select_curve->CheckedChanged += gcnew System::EventHandler(this, &FormRefCurveDeform::m_cb_onlyselectedcurve_CheckedChanged);
-			// 
-			// m_trackbar_mcstride
-			// 
-			this->m_trackbar_mcstride->LargeChange = 1;
-			this->m_trackbar_mcstride->Location = System::Drawing::Point(147, 10);
-			this->m_trackbar_mcstride->Maximum = 4;
-			this->m_trackbar_mcstride->Minimum = 1;
-			this->m_trackbar_mcstride->Name = L"m_trackbar_mcstride";
-			this->m_trackbar_mcstride->Size = System::Drawing::Size(139, 45);
-			this->m_trackbar_mcstride->TabIndex = 28;
-			this->m_trackbar_mcstride->Value = 2;
-			// 
-			// label1
-			// 
-			this->label1->AutoSize = true;
-			this->label1->Location = System::Drawing::Point(152, 43);
-			this->label1->Name = L"label1";
-			this->label1->Size = System::Drawing::Size(17, 12);
-			this->label1->TabIndex = 29;
-			this->label1->Text = L"x1";
-			// 
-			// label2
-			// 
-			this->label2->AutoSize = true;
-			this->label2->Location = System::Drawing::Point(190, 43);
-			this->label2->Name = L"label2";
-			this->label2->Size = System::Drawing::Size(17, 12);
-			this->label2->TabIndex = 29;
-			this->label2->Text = L"x2";
-			// 
-			// label3
-			// 
-			this->label3->AutoSize = true;
-			this->label3->Location = System::Drawing::Point(228, 43);
-			this->label3->Name = L"label3";
-			this->label3->Size = System::Drawing::Size(17, 12);
-			this->label3->TabIndex = 29;
-			this->label3->Text = L"x4";
-			// 
-			// label4
-			// 
-			this->label4->AutoSize = true;
-			this->label4->Location = System::Drawing::Point(17, 85);
-			this->label4->Name = L"label4";
-			this->label4->Size = System::Drawing::Size(46, 12);
-			this->label4->TabIndex = 26;
-			this->label4->Text = L"CP size:";
-			// 
-			// label5
-			// 
-			this->label5->AutoSize = true;
-			this->label5->Location = System::Drawing::Point(265, 43);
-			this->label5->Name = L"label5";
-			this->label5->Size = System::Drawing::Size(17, 12);
-			this->label5->TabIndex = 29;
-			this->label5->Text = L"x8";
-			// 
-			// m_btn_reload_mesh
-			// 
-			this->m_btn_reload_mesh->Font = (gcnew System::Drawing::Font(L"MS UI Gothic", 9, System::Drawing::FontStyle::Regular, System::Drawing::GraphicsUnit::Point,
-				static_cast<System::Byte>(128)));
-			this->m_btn_reload_mesh->Location = System::Drawing::Point(8, 38);
-			this->m_btn_reload_mesh->Name = L"m_btn_reload_mesh";
-			this->m_btn_reload_mesh->Size = System::Drawing::Size(135, 23);
-			this->m_btn_reload_mesh->TabIndex = 0;
-			this->m_btn_reload_mesh->Text = L"Reload mesh";
-			this->m_btn_reload_mesh->UseVisualStyleBackColor = true;
-			this->m_btn_reload_mesh->Click += gcnew System::EventHandler(this, &FormRefCurveDeform::m_btn_reload_mesh_Click);
-			// 
-			// m_btn_sharestroke
-			// 
-			this->m_btn_sharestroke->Location = System::Drawing::Point(6, 129);
-			this->m_btn_sharestroke->Name = L"m_btn_sharestroke";
-			this->m_btn_sharestroke->Size = System::Drawing::Size(133, 23);
-			this->m_btn_sharestroke->TabIndex = 1;
-			this->m_btn_sharestroke->Text = L"Set as all frame curve";
-			this->m_btn_sharestroke->UseVisualStyleBackColor = true;
-			this->m_btn_sharestroke->Click += gcnew System::EventHandler(this, &FormRefCurveDeform::m_btn_sharestroke_Click);
-			// 
-			// m_btn_loadstate
-			// 
-			this->m_btn_loadstate->Location = System::Drawing::Point(153, 202);
-			this->m_btn_loadstate->Name = L"m_btn_loadstate";
-			this->m_btn_loadstate->Size = System::Drawing::Size(68, 32);
-			this->m_btn_loadstate->TabIndex = 1;
-			this->m_btn_loadstate->Text = L"Load state";
-			this->m_btn_loadstate->UseVisualStyleBackColor = true;
-			this->m_btn_loadstate->Click += gcnew System::EventHandler(this, &FormRefCurveDeform::m_btn_loadstate_Click);
-			// 
-			// m_btn_savestate
-			// 
-			this->m_btn_savestate->Location = System::Drawing::Point(227, 202);
-			this->m_btn_savestate->Name = L"m_btn_savestate";
-			this->m_btn_savestate->Size = System::Drawing::Size(68, 32);
-			this->m_btn_savestate->TabIndex = 1;
-			this->m_btn_savestate->Text = L"Save state";
-			this->m_btn_savestate->UseVisualStyleBackColor = true;
-			this->m_btn_savestate->Click += gcnew System::EventHandler(this, &FormRefCurveDeform::m_btn_savestate_Click);
-			// 
-			// m_btn_flipnormal
-			// 
-			this->m_btn_flipnormal->Location = System::Drawing::Point(6, 158);
-			this->m_btn_flipnormal->Name = L"m_btn_flipnormal";
-			this->m_btn_flipnormal->Size = System::Drawing::Size(133, 23);
-			this->m_btn_flipnormal->TabIndex = 30;
-			this->m_btn_flipnormal->Text = L"flip normals";
-			this->m_btn_flipnormal->UseVisualStyleBackColor = true;
-			this->m_btn_flipnormal->Click += gcnew System::EventHandler(this, &FormRefCurveDeform::m_btn_flipnormal_Click);
-			// 
-			// m_btn_deform_all
-			// 
-			this->m_btn_deform_all->Location = System::Drawing::Point(154, 252);
-			this->m_btn_deform_all->Name = L"m_btn_deform_all";
-			this->m_btn_deform_all->Size = System::Drawing::Size(135, 32);
-			this->m_btn_deform_all->TabIndex = 31;
-			this->m_btn_deform_all->Text = L"Deform All Frame";
-			this->m_btn_deform_all->UseVisualStyleBackColor = true;
-			this->m_btn_deform_all->Click += gcnew System::EventHandler(this, &FormRefCurveDeform::m_btn_deform_all_Click);
-			// 
-			// m_cancel
-			// 
-			this->m_cancel->Location = System::Drawing::Point(46, 309);
-			this->m_cancel->Name = L"m_cancel";
-			this->m_cancel->Size = System::Drawing::Size(93, 32);
-			this->m_cancel->TabIndex = 32;
-			this->m_cancel->Text = L"Cancel";
-			this->m_cancel->UseVisualStyleBackColor = true;
-			this->m_cancel->Click += gcnew System::EventHandler(this, &FormRefCurveDeform::m_cancel_Click);
-			// 
-			// m_finish
-			// 
-			this->m_finish->Location = System::Drawing::Point(154, 309);
-			this->m_finish->Name = L"m_finish";
-			this->m_finish->Size = System::Drawing::Size(135, 32);
-			this->m_finish->TabIndex = 33;
-			this->m_finish->Text = L"Finish Segmentation";
-			this->m_finish->UseVisualStyleBackColor = true;
-			this->m_finish->Click += gcnew System::EventHandler(this, &FormRefCurveDeform::m_finish_Click);
-			// 
-			// FormRefCurveDeform
-			// 
-			this->AutoScaleDimensions = System::Drawing::SizeF(6, 12);
-			this->AutoScaleMode = System::Windows::Forms::AutoScaleMode::Font;
-			this->ClientSize = System::Drawing::Size(300, 397);
-			this->Controls->Add(this->m_finish);
-			this->Controls->Add(this->m_cancel);
-			this->Controls->Add(this->m_btn_deform_all);
-			this->Controls->Add(this->m_btn_flipnormal);
-			this->Controls->Add(this->label5);
-			this->Controls->Add(this->label3);
-			this->Controls->Add(this->label2);
-			this->Controls->Add(this->label1);
-			this->Controls->Add(this->m_trackbar_mcstride);
-			this->Controls->Add(this->m_cb_only_select_curve);
-			this->Controls->Add(this->label4);
-			this->Controls->Add(this->m_numbox_cpsize);
-			this->Controls->Add(this->m_btn_undo);
-			this->Controls->Add(this->m_btn_copy_to_allframe);
-			this->Controls->Add(this->m_btn_sharestroke);
-			this->Controls->Add(this->m_btn_savestate);
-			this->Controls->Add(this->m_btn_loadstate);
-			this->Controls->Add(this->m_btn_copy_from_preframe);
-			this->Controls->Add(this->m_btn_deform);
-			this->Controls->Add(this->m_btn_reload_mesh);
-			this->Controls->Add(this->m_btn_genmesh);
-			this->Name = L"FormRefCurveDeform";
-			this->Text = L"RefCurveDeform";
-			(cli::safe_cast<System::ComponentModel::ISupportInitialize^>(this->m_numbox_cpsize))->EndInit();
-			(cli::safe_cast<System::ComponentModel::ISupportInitialize^>(this->m_trackbar_mcstride))->EndInit();
-			this->ResumeLayout(false);
-			this->PerformLayout();
-
-		}
+    /// <summary>
+    /// デザイナー サポートに必要なメソッドです。このメソッドの内容を
+    /// コード エディターで変更しないでください。
+    /// </summary>
+    void InitializeComponent(void)
+    {
+      this->m_btn_genmesh = (gcnew System::Windows::Forms::Button());
+      this->m_btn_deform = (gcnew System::Windows::Forms::Button());
+      this->m_btn_undo = (gcnew System::Windows::Forms::Button());
+      this->m_btn_copy_from_preframe = (gcnew System::Windows::Forms::Button());
+      this->m_btn_copy_to_allframe = (gcnew System::Windows::Forms::Button());
+      this->m_numbox_cpsize = (gcnew System::Windows::Forms::NumericUpDown());
+      this->m_cb_only_select_curve = (gcnew System::Windows::Forms::CheckBox());
+      this->m_trackbar_mcstride = (gcnew System::Windows::Forms::TrackBar());
+      this->label1 = (gcnew System::Windows::Forms::Label());
+      this->label2 = (gcnew System::Windows::Forms::Label());
+      this->label3 = (gcnew System::Windows::Forms::Label());
+      this->label4 = (gcnew System::Windows::Forms::Label());
+      this->label5 = (gcnew System::Windows::Forms::Label());
+      this->m_btn_reload_mesh = (gcnew System::Windows::Forms::Button());
+      this->m_btn_sharestroke = (gcnew System::Windows::Forms::Button());
+      this->m_btn_loadstate = (gcnew System::Windows::Forms::Button());
+      this->m_btn_savestate = (gcnew System::Windows::Forms::Button());
+      this->m_btn_flipnormal = (gcnew System::Windows::Forms::Button());
+      this->m_btn_deform_all = (gcnew System::Windows::Forms::Button());
+      this->m_btn_cancel = (gcnew System::Windows::Forms::Button());
+      this->m_btn_finish = (gcnew System::Windows::Forms::Button());
+      (cli::safe_cast<System::ComponentModel::ISupportInitialize^>(this->m_numbox_cpsize))->BeginInit();
+      (cli::safe_cast<System::ComponentModel::ISupportInitialize^>(this->m_trackbar_mcstride))->BeginInit();
+      this->SuspendLayout();
+      // 
+      // m_btn_genmesh
+      // 
+      this->m_btn_genmesh->Font = (gcnew System::Drawing::Font(L"MS UI Gothic", 9, System::Drawing::FontStyle::Regular, System::Drawing::GraphicsUnit::Point,
+    	static_cast<System::Byte>(128)));
+      this->m_btn_genmesh->Location = System::Drawing::Point(8, 10);
+      this->m_btn_genmesh->Name = L"m_btn_genmesh";
+      this->m_btn_genmesh->Size = System::Drawing::Size(135, 23);
+      this->m_btn_genmesh->TabIndex = 0;
+      this->m_btn_genmesh->Text = L"Create Mesh Models";
+      this->m_btn_genmesh->UseVisualStyleBackColor = true;
+      this->m_btn_genmesh->Click += gcnew System::EventHandler(this, &FormRefCurveDeform::m_btn_genmesh_Click);
+      // 
+      // m_btn_deform
+      // 
+      this->m_btn_deform->Location = System::Drawing::Point(4, 252);
+      this->m_btn_deform->Name = L"m_btn_deform";
+      this->m_btn_deform->Size = System::Drawing::Size(135, 32);
+      this->m_btn_deform->TabIndex = 1;
+      this->m_btn_deform->Text = L"Deform Current Frame";
+      this->m_btn_deform->UseVisualStyleBackColor = true;
+      this->m_btn_deform->Click += gcnew System::EventHandler(this, &FormRefCurveDeform::m_btn_deform_Click);
+      // 
+      // m_btn_undo
+      // 
+      this->m_btn_undo->Location = System::Drawing::Point(28, 187);
+      this->m_btn_undo->Name = L"m_btn_undo";
+      this->m_btn_undo->Size = System::Drawing::Size(89, 23);
+      this->m_btn_undo->TabIndex = 2;
+      this->m_btn_undo->Text = L"UNDO";
+      this->m_btn_undo->UseVisualStyleBackColor = true;
+      this->m_btn_undo->Click += gcnew System::EventHandler(this, &FormRefCurveDeform::m_btn_undo_Click);
+      // 
+      // m_btn_copy_from_preframe
+      // 
+      this->m_btn_copy_from_preframe->Location = System::Drawing::Point(153, 118);
+      this->m_btn_copy_from_preframe->Name = L"m_btn_copy_from_preframe";
+      this->m_btn_copy_from_preframe->Size = System::Drawing::Size(142, 36);
+      this->m_btn_copy_from_preframe->TabIndex = 1;
+      this->m_btn_copy_from_preframe->Text = L"Copy curves from prev frame";
+      this->m_btn_copy_from_preframe->UseVisualStyleBackColor = true;
+      this->m_btn_copy_from_preframe->Click += gcnew System::EventHandler(this, &FormRefCurveDeform::m_btn_copy_from_preframe_Click);
+      // 
+      // m_btn_copy_to_allframe
+      // 
+      this->m_btn_copy_to_allframe->Location = System::Drawing::Point(153, 160);
+      this->m_btn_copy_to_allframe->Name = L"m_btn_copy_to_allframe";
+      this->m_btn_copy_to_allframe->Size = System::Drawing::Size(142, 36);
+      this->m_btn_copy_to_allframe->TabIndex = 1;
+      this->m_btn_copy_to_allframe->Text = L"Copy curves in this fame to all frame";
+      this->m_btn_copy_to_allframe->UseVisualStyleBackColor = true;
+      this->m_btn_copy_to_allframe->Click += gcnew System::EventHandler(this, &FormRefCurveDeform::m_btn_copy_to_allframe_Click);
+      // 
+      // m_numbox_cpsize
+      // 
+      this->m_numbox_cpsize->Font = (gcnew System::Drawing::Font(L"MS UI Gothic", 11.5F));
+      this->m_numbox_cpsize->Location = System::Drawing::Point(69, 81);
+      this->m_numbox_cpsize->Minimum = System::Decimal(gcnew cli::array< System::Int32 >(4) { 1, 0, 0, 0 });
+      this->m_numbox_cpsize->Name = L"m_numbox_cpsize";
+      this->m_numbox_cpsize->Size = System::Drawing::Size(57, 23);
+      this->m_numbox_cpsize->TabIndex = 25;
+      this->m_numbox_cpsize->TextAlign = System::Windows::Forms::HorizontalAlignment::Right;
+      this->m_numbox_cpsize->Value = System::Decimal(gcnew cli::array< System::Int32 >(4) { 10, 0, 0, 0 });
+      this->m_numbox_cpsize->ValueChanged += gcnew System::EventHandler(this, &FormRefCurveDeform::m_numbox_cpsize_ValueChanged);
+      // 
+      // m_cb_only_select_curve
+      // 
+      this->m_cb_only_select_curve->AutoSize = true;
+      this->m_cb_only_select_curve->Font = (gcnew System::Drawing::Font(L"MS UI Gothic", 8));
+      this->m_cb_only_select_curve->Location = System::Drawing::Point(147, 85);
+      this->m_cb_only_select_curve->Name = L"m_cb_only_select_curve";
+      this->m_cb_only_select_curve->Size = System::Drawing::Size(148, 15);
+      this->m_cb_only_select_curve->TabIndex = 27;
+      this->m_cb_only_select_curve->Text = L"Show only selected stroke";
+      this->m_cb_only_select_curve->UseVisualStyleBackColor = true;
+      this->m_cb_only_select_curve->CheckedChanged += gcnew System::EventHandler(this, &FormRefCurveDeform::m_cb_onlyselectedcurve_CheckedChanged);
+      // 
+      // m_trackbar_mcstride
+      // 
+      this->m_trackbar_mcstride->LargeChange = 1;
+      this->m_trackbar_mcstride->Location = System::Drawing::Point(147, 10);
+      this->m_trackbar_mcstride->Maximum = 4;
+      this->m_trackbar_mcstride->Minimum = 1;
+      this->m_trackbar_mcstride->Name = L"m_trackbar_mcstride";
+      this->m_trackbar_mcstride->Size = System::Drawing::Size(139, 45);
+      this->m_trackbar_mcstride->TabIndex = 28;
+      this->m_trackbar_mcstride->Value = 2;
+      // 
+      // label1
+      // 
+      this->label1->AutoSize = true;
+      this->label1->Location = System::Drawing::Point(152, 43);
+      this->label1->Name = L"label1";
+      this->label1->Size = System::Drawing::Size(17, 12);
+      this->label1->TabIndex = 29;
+      this->label1->Text = L"x1";
+      // 
+      // label2
+      // 
+      this->label2->AutoSize = true;
+      this->label2->Location = System::Drawing::Point(190, 43);
+      this->label2->Name = L"label2";
+      this->label2->Size = System::Drawing::Size(17, 12);
+      this->label2->TabIndex = 29;
+      this->label2->Text = L"x2";
+      // 
+      // label3
+      // 
+      this->label3->AutoSize = true;
+      this->label3->Location = System::Drawing::Point(228, 43);
+      this->label3->Name = L"label3";
+      this->label3->Size = System::Drawing::Size(17, 12);
+      this->label3->TabIndex = 29;
+      this->label3->Text = L"x4";
+      // 
+      // label4
+      // 
+      this->label4->AutoSize = true;
+      this->label4->Location = System::Drawing::Point(17, 85);
+      this->label4->Name = L"label4";
+      this->label4->Size = System::Drawing::Size(46, 12);
+      this->label4->TabIndex = 26;
+      this->label4->Text = L"CP size:";
+      // 
+      // label5
+      // 
+      this->label5->AutoSize = true;
+      this->label5->Location = System::Drawing::Point(265, 43);
+      this->label5->Name = L"label5";
+      this->label5->Size = System::Drawing::Size(17, 12);
+      this->label5->TabIndex = 29;
+      this->label5->Text = L"x8";
+      // 
+      // m_btn_reload_mesh
+      // 
+      this->m_btn_reload_mesh->Font = (gcnew System::Drawing::Font(L"MS UI Gothic", 9, System::Drawing::FontStyle::Regular, System::Drawing::GraphicsUnit::Point,
+    	static_cast<System::Byte>(128)));
+      this->m_btn_reload_mesh->Location = System::Drawing::Point(8, 38);
+      this->m_btn_reload_mesh->Name = L"m_btn_reload_mesh";
+      this->m_btn_reload_mesh->Size = System::Drawing::Size(135, 23);
+      this->m_btn_reload_mesh->TabIndex = 0;
+      this->m_btn_reload_mesh->Text = L"Reload mesh";
+      this->m_btn_reload_mesh->UseVisualStyleBackColor = true;
+      this->m_btn_reload_mesh->Click += gcnew System::EventHandler(this, &FormRefCurveDeform::m_btn_reload_mesh_Click);
+      // 
+      // m_btn_sharestroke
+      // 
+      this->m_btn_sharestroke->Location = System::Drawing::Point(6, 129);
+      this->m_btn_sharestroke->Name = L"m_btn_sharestroke";
+      this->m_btn_sharestroke->Size = System::Drawing::Size(133, 23);
+      this->m_btn_sharestroke->TabIndex = 1;
+      this->m_btn_sharestroke->Text = L"Set as all frame curve";
+      this->m_btn_sharestroke->UseVisualStyleBackColor = true;
+      this->m_btn_sharestroke->Click += gcnew System::EventHandler(this, &FormRefCurveDeform::m_btn_sharestroke_Click);
+      // 
+      // m_btn_loadstate
+      // 
+      this->m_btn_loadstate->Location = System::Drawing::Point(153, 202);
+      this->m_btn_loadstate->Name = L"m_btn_loadstate";
+      this->m_btn_loadstate->Size = System::Drawing::Size(68, 32);
+      this->m_btn_loadstate->TabIndex = 1;
+      this->m_btn_loadstate->Text = L"Load state";
+      this->m_btn_loadstate->UseVisualStyleBackColor = true;
+      this->m_btn_loadstate->Click += gcnew System::EventHandler(this, &FormRefCurveDeform::m_btn_loadstate_Click);
+      // 
+      // m_btn_savestate
+      // 
+      this->m_btn_savestate->Location = System::Drawing::Point(227, 202);
+      this->m_btn_savestate->Name = L"m_btn_savestate";
+      this->m_btn_savestate->Size = System::Drawing::Size(68, 32);
+      this->m_btn_savestate->TabIndex = 1;
+      this->m_btn_savestate->Text = L"Save state";
+      this->m_btn_savestate->UseVisualStyleBackColor = true;
+      this->m_btn_savestate->Click += gcnew System::EventHandler(this, &FormRefCurveDeform::m_btn_savestate_Click);
+      // 
+      // m_btn_flipnormal
+      // 
+      this->m_btn_flipnormal->Location = System::Drawing::Point(6, 158);
+      this->m_btn_flipnormal->Name = L"m_btn_flipnormal";
+      this->m_btn_flipnormal->Size = System::Drawing::Size(133, 23);
+      this->m_btn_flipnormal->TabIndex = 30;
+      this->m_btn_flipnormal->Text = L"flip normals";
+      this->m_btn_flipnormal->UseVisualStyleBackColor = true;
+      this->m_btn_flipnormal->Click += gcnew System::EventHandler(this, &FormRefCurveDeform::m_btn_flipnormal_Click);
+      // 
+      // m_btn_deform_all
+      // 
+      this->m_btn_deform_all->Location = System::Drawing::Point(154, 252);
+      this->m_btn_deform_all->Name = L"m_btn_deform_all";
+      this->m_btn_deform_all->Size = System::Drawing::Size(135, 32);
+      this->m_btn_deform_all->TabIndex = 31;
+      this->m_btn_deform_all->Text = L"Deform All Frame";
+      this->m_btn_deform_all->UseVisualStyleBackColor = true;
+      this->m_btn_deform_all->Click += gcnew System::EventHandler(this, &FormRefCurveDeform::m_btn_deform_all_Click);
+      // 
+      // m_cancel
+      // 
+      this->m_btn_cancel->Location = System::Drawing::Point(46, 309);
+      this->m_btn_cancel->Name = L"m_cancel";
+      this->m_btn_cancel->Size = System::Drawing::Size(93, 32);
+      this->m_btn_cancel->TabIndex = 32;
+      this->m_btn_cancel->Text = L"Cancel";
+      this->m_btn_cancel->UseVisualStyleBackColor = true;
+      this->m_btn_cancel->Click += gcnew System::EventHandler(this, &FormRefCurveDeform::m_cancel_Click);
+      // 
+      // m_finish
+      // 
+      this->m_btn_finish->Location = System::Drawing::Point(154, 309);
+      this->m_btn_finish->Name = L"m_finish";
+      this->m_btn_finish->Size = System::Drawing::Size(135, 32);
+      this->m_btn_finish->TabIndex = 33;
+      this->m_btn_finish->Text = L"Finish Segmentation";
+      this->m_btn_finish->UseVisualStyleBackColor = true;
+      this->m_btn_finish->Click += gcnew System::EventHandler(this, &FormRefCurveDeform::m_finish_Click);
+      // 
+      // FormRefCurveDeform
+      // 
+      this->AutoScaleDimensions = System::Drawing::SizeF(6, 12);
+      this->AutoScaleMode = System::Windows::Forms::AutoScaleMode::Font;
+      this->ClientSize = System::Drawing::Size(300, 397);
+      this->Controls->Add(this->m_btn_finish);
+      this->Controls->Add(this->m_btn_cancel);
+      this->Controls->Add(this->m_btn_deform_all);
+      this->Controls->Add(this->m_btn_flipnormal);
+      this->Controls->Add(this->label5);
+      this->Controls->Add(this->label3);
+      this->Controls->Add(this->label2);
+      this->Controls->Add(this->label1);
+      this->Controls->Add(this->m_trackbar_mcstride);
+      this->Controls->Add(this->m_cb_only_select_curve);
+      this->Controls->Add(this->label4);
+      this->Controls->Add(this->m_numbox_cpsize);
+      this->Controls->Add(this->m_btn_undo);
+      this->Controls->Add(this->m_btn_copy_to_allframe);
+      this->Controls->Add(this->m_btn_sharestroke);
+      this->Controls->Add(this->m_btn_savestate);
+      this->Controls->Add(this->m_btn_loadstate);
+      this->Controls->Add(this->m_btn_copy_from_preframe);
+      this->Controls->Add(this->m_btn_deform);
+      this->Controls->Add(this->m_btn_reload_mesh);
+      this->Controls->Add(this->m_btn_genmesh);
+      this->Name = L"FormRefCurveDeform";
+      this->Text = L"RefCurveDeform";
+      (cli::safe_cast<System::ComponentModel::ISupportInitialize^>(this->m_numbox_cpsize))->EndInit();
+      (cli::safe_cast<System::ComponentModel::ISupportInitialize^>(this->m_trackbar_mcstride))->EndInit();
+      this->ResumeLayout(false);
+      this->PerformLayout();
+    
+    }
 #pragma endregion
 	private:
-		System::Void m_numbox_cpsize_ValueChanged(System::Object^ sender, System::EventArgs^ e);
-		System::Void m_cancel_Click         (System::Object^ sender, System::EventArgs^ e);
-		System::Void m_finish_Click         (System::Object^ sender, System::EventArgs^ e);
-		System::Void m_btn_genmesh_Click    (System::Object^ sender, System::EventArgs^ e);
-		System::Void m_btn_reload_mesh_Click(System::Object^ sender, System::EventArgs^ e);
-		System::Void m_btn_deform_Click     (System::Object^ sender, System::EventArgs^ e);
-		System::Void m_btn_deform_all_Click(System::Object^ sender, System::EventArgs^ e);
-		System::Void m_btn_loadstate_Click  (System::Object^ sender, System::EventArgs^ e);
-		System::Void m_btn_savestate_Click  (System::Object^ sender, System::EventArgs^ e);
-		System::Void m_btn_undo_Click       (System::Object^ sender, System::EventArgs^ e);
-		System::Void m_btn_flipnormal_Click (System::Object^ sender, System::EventArgs^ e);
-		System::Void m_btn_copy_from_preframe_Click(System::Object^ sender, System::EventArgs^ e);
-		System::Void m_btn_copy_to_allframe_Click(System::Object^ sender, System::EventArgs^ e);
-		System::Void m_btn_sharestroke_Click(System::Object^ sender, System::EventArgs^ e);
-		System::Void m_cb_onlyselectedcurve_CheckedChanged(System::Object^ sender, System::EventArgs^ e);
+	  System::Void m_numbox_cpsize_ValueChanged(System::Object^ sender, System::EventArgs^ e);
+	  System::Void m_cancel_Click         (System::Object^ sender, System::EventArgs^ e);
+	  System::Void m_finish_Click         (System::Object^ sender, System::EventArgs^ e);
+	  System::Void m_btn_genmesh_Click    (System::Object^ sender, System::EventArgs^ e);
+	  System::Void m_btn_reload_mesh_Click(System::Object^ sender, System::EventArgs^ e);
+	  System::Void m_btn_deform_Click     (System::Object^ sender, System::EventArgs^ e);
+	  System::Void m_btn_deform_all_Click(System::Object^ sender, System::EventArgs^ e);
+	  System::Void m_btn_loadstate_Click  (System::Object^ sender, System::EventArgs^ e);
+	  System::Void m_btn_savestate_Click  (System::Object^ sender, System::EventArgs^ e);
+	  System::Void m_btn_undo_Click       (System::Object^ sender, System::EventArgs^ e);
+	  System::Void m_btn_flipnormal_Click (System::Object^ sender, System::EventArgs^ e);
+	  System::Void m_btn_copy_from_preframe_Click(System::Object^ sender, System::EventArgs^ e);
+	  System::Void m_btn_copy_to_allframe_Click(System::Object^ sender, System::EventArgs^ e);
+	  System::Void m_btn_sharestroke_Click(System::Object^ sender, System::EventArgs^ e);
+	  System::Void m_cb_onlyselectedcurve_CheckedChanged(System::Object^ sender, System::EventArgs^ e);
 	public:
-		int  GetCpSize (){ return static_cast<int>(m_numbox_cpsize->Value); }
-		int  GetMcStride(){ return static_cast<int>(m_trackbar_mcstride->Value);}
-		bool bVisOnlySelectedCurve(){
-			return static_cast<bool>(m_cb_only_select_curve->Checked);
-		}
+	  int  GetCpSize (){ return static_cast<int>(m_numbox_cpsize->Value); }
+	  int  GetMcStride(){ return static_cast<int>(m_trackbar_mcstride->Value);}
+	  bool bVisOnlySelectedCurve(){
+	  	return static_cast<bool>(m_cb_only_select_curve->Checked);
+	  }
 };
 
 	inline void FormRefCurveDeform_Show() { FormRefCurveDeform::GetInst()->Show(); }
-  inline void FormRefCurveDeform_Hide() { FormRefCurveDeform::GetInst()->Hide(); }
-  inline void FormRefCurveDeform_InitAllItems() { FormRefCurveDeform::GetInst()->InitAllItems(); }
+	inline void FormRefCurveDeform_Hide() { FormRefCurveDeform::GetInst()->Hide(); }
+	inline void FormRefCurveDeform_InitAllItems() { FormRefCurveDeform::GetInst()->InitAllItems(); }
 
 	inline int  FormRefCurveDeform_GetCpSize()       { return FormRefCurveDeform::GetInst()->GetCpSize(); }
 	inline bool FormRefCurveDeform_VisOnlySelCurve() { return FormRefCurveDeform::GetInst()->bVisOnlySelectedCurve(); }

--- a/RoiPainter4D/RoiPainter4D/FormSegStrokeFfd.cpp
+++ b/RoiPainter4D/RoiPainter4D/FormSegStrokeFfd.cpp
@@ -118,6 +118,11 @@ System::Void FormSegStrokeFfd::m_btn_sharestroke_Click(System::Object^ sender, S
   ModeSegStrokeFfd::GetInst()->MakeSelectedStroke_Shared();
 }
 
+System::Void FormSegStrokeFfd::m_btn_flipnormal_Click(System::Object^ sender, System::EventArgs^ e)
+{
+  ModeSegStrokeFfd::GetInst()->FlipSelectedStrokeNormalSide();
+}
+
 System::Void FormSegStrokeFfd::m_btn_copycagetoallframes_Click(System::Object^ sender, System::EventArgs^ e)
 {
   ModeSegStrokeFfd::GetInst()->CopyCageToAllFrames();

--- a/RoiPainter4D/RoiPainter4D/FormSegStrokeFfd.h
+++ b/RoiPainter4D/RoiPainter4D/FormSegStrokeFfd.h
@@ -62,6 +62,7 @@ namespace RoiPainter4D {
   private: System::Windows::Forms::Button^ m_btn_copyfromprevframe;
   private: System::Windows::Forms::Button^ m_btn_deform;
   private: System::Windows::Forms::Button^ m_btn_sharestroke;
+  private: System::Windows::Forms::Button^ m_btn_flipnormal;
   private: System::Windows::Forms::Button^ m_btn_copycagetoallframes;
   private: System::Windows::Forms::Button^ m_btn_finish_segmentation;
 
@@ -94,388 +95,400 @@ namespace RoiPainter4D {
     /// </summary>
     void InitializeComponent(void)
     {
-        this->m_btn_loadmeshandcage = (gcnew System::Windows::Forms::Button());
-        this->m_btn_savemeshandcage = (gcnew System::Windows::Forms::Button());
-        this->m_btn_loadstate = (gcnew System::Windows::Forms::Button());
-        this->m_btn_savestate = (gcnew System::Windows::Forms::Button());
-        this->m_textbox_alpha = (gcnew System::Windows::Forms::TextBox());
-        this->m_textbox_beta = (gcnew System::Windows::Forms::TextBox());
-        this->m_textbox_gamma = (gcnew System::Windows::Forms::TextBox());
-        this->m_btn_deform = (gcnew System::Windows::Forms::Button());
-        this->label1 = (gcnew System::Windows::Forms::Label());
-        this->label2 = (gcnew System::Windows::Forms::Label());
-        this->label3 = (gcnew System::Windows::Forms::Label());
-        this->m_btn_undo = (gcnew System::Windows::Forms::Button());
-        this->m_btn_copyfromprevframe = (gcnew System::Windows::Forms::Button());
-        this->m_radiobtn_movement = (gcnew System::Windows::Forms::RadioButton());
-        this->m_radiobtn_rotation = (gcnew System::Windows::Forms::RadioButton());
-        this->m_radiobtn_scaling = (gcnew System::Windows::Forms::RadioButton());
-        this->m_btn_sharestroke = (gcnew System::Windows::Forms::Button());
-        this->m_radiobtn_stroke = (gcnew System::Windows::Forms::RadioButton());
-        this->m_radiobtn_cage = (gcnew System::Windows::Forms::RadioButton());
-        this->groupBox1 = (gcnew System::Windows::Forms::GroupBox());
-        this->groupBox2 = (gcnew System::Windows::Forms::GroupBox());
-        this->m_numbox_cpsize = (gcnew System::Windows::Forms::NumericUpDown());
-        this->label4 = (gcnew System::Windows::Forms::Label());
-        this->m_checkbox_showonlyselectedstroke = (gcnew System::Windows::Forms::CheckBox());
-        this->m_btn_copycagetoallframes = (gcnew System::Windows::Forms::Button());
-        this->groupBox3 = (gcnew System::Windows::Forms::GroupBox());
-        this->label6 = (gcnew System::Windows::Forms::Label());
-        this->label5 = (gcnew System::Windows::Forms::Label());
-        this->m_btn_finish_segmentation = (gcnew System::Windows::Forms::Button());
-        this->groupBox1->SuspendLayout();
-        this->groupBox2->SuspendLayout();
-        (cli::safe_cast<System::ComponentModel::ISupportInitialize^>(this->m_numbox_cpsize))->BeginInit();
-        this->groupBox3->SuspendLayout();
-        this->SuspendLayout();
-        // 
-        // m_btn_loadmeshandcage
-        // 
-        this->m_btn_loadmeshandcage->Location = System::Drawing::Point(12, 12);
-        this->m_btn_loadmeshandcage->Name = L"m_btn_loadmeshandcage";
-        this->m_btn_loadmeshandcage->Size = System::Drawing::Size(138, 23);
-        this->m_btn_loadmeshandcage->TabIndex = 0;
-        this->m_btn_loadmeshandcage->Text = L"Import mesh＆cage";
-        this->m_btn_loadmeshandcage->UseVisualStyleBackColor = true;
-        this->m_btn_loadmeshandcage->Click += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_btn_loadmeshandcage_Click);
-        // 
-        // m_btn_savemeshandcage
-        // 
-        this->m_btn_savemeshandcage->Location = System::Drawing::Point(153, 12);
-        this->m_btn_savemeshandcage->Margin = System::Windows::Forms::Padding(2);
-        this->m_btn_savemeshandcage->Name = L"m_btn_savemeshandcage";
-        this->m_btn_savemeshandcage->Size = System::Drawing::Size(120, 23);
-        this->m_btn_savemeshandcage->TabIndex = 1;
-        this->m_btn_savemeshandcage->Text = L"Export mesh＆cage";
-        this->m_btn_savemeshandcage->UseVisualStyleBackColor = true;
-        this->m_btn_savemeshandcage->Click += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_btn_savemeshandcage_Click);
-        // 
-        // m_btn_loadstate
-        // 
-        this->m_btn_loadstate->Location = System::Drawing::Point(14, 425);
-        this->m_btn_loadstate->Margin = System::Windows::Forms::Padding(2);
-        this->m_btn_loadstate->Name = L"m_btn_loadstate";
-        this->m_btn_loadstate->Size = System::Drawing::Size(142, 23);
-        this->m_btn_loadstate->TabIndex = 2;
-        this->m_btn_loadstate->Text = L"Load cage and curves";
-        this->m_btn_loadstate->UseVisualStyleBackColor = true;
-        this->m_btn_loadstate->Click += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_btn_loadstate_Click);
-        // 
-        // m_btn_savestate
-        // 
-        this->m_btn_savestate->Location = System::Drawing::Point(14, 398);
-        this->m_btn_savestate->Margin = System::Windows::Forms::Padding(2);
-        this->m_btn_savestate->Name = L"m_btn_savestate";
-        this->m_btn_savestate->Size = System::Drawing::Size(142, 23);
-        this->m_btn_savestate->TabIndex = 3;
-        this->m_btn_savestate->Text = L"Save Cage and curves";
-        this->m_btn_savestate->UseVisualStyleBackColor = true;
-        this->m_btn_savestate->Click += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_btn_savestate_Click);
-        // 
-        // m_textbox_alpha
-        // 
-        this->m_textbox_alpha->Location = System::Drawing::Point(199, 18);
-        this->m_textbox_alpha->Name = L"m_textbox_alpha";
-        this->m_textbox_alpha->Size = System::Drawing::Size(38, 19);
-        this->m_textbox_alpha->TabIndex = 4;
-        this->m_textbox_alpha->Text = L"1.0";
-        // 
-        // m_textbox_beta
-        // 
-        this->m_textbox_beta->Location = System::Drawing::Point(199, 43);
-        this->m_textbox_beta->Name = L"m_textbox_beta";
-        this->m_textbox_beta->Size = System::Drawing::Size(38, 19);
-        this->m_textbox_beta->TabIndex = 5;
-        this->m_textbox_beta->Text = L"1.0";
-        // 
-        // m_textbox_gamma
-        // 
-        this->m_textbox_gamma->Location = System::Drawing::Point(199, 68);
-        this->m_textbox_gamma->Name = L"m_textbox_gamma";
-        this->m_textbox_gamma->Size = System::Drawing::Size(38, 19);
-        this->m_textbox_gamma->TabIndex = 6;
-        this->m_textbox_gamma->Text = L"5.0";
-        // 
-        // m_btn_deform
-        // 
-        this->m_btn_deform->Location = System::Drawing::Point(6, 17);
-        this->m_btn_deform->Margin = System::Windows::Forms::Padding(2);
-        this->m_btn_deform->Name = L"m_btn_deform";
-        this->m_btn_deform->Size = System::Drawing::Size(157, 32);
-        this->m_btn_deform->TabIndex = 7;
-        this->m_btn_deform->Text = L"Deform (変形を計算)";
-        this->m_btn_deform->UseVisualStyleBackColor = true;
-        this->m_btn_deform->Click += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_btn_deform_Click);
-        // 
-        // label1
-        // 
-        this->label1->AutoSize = true;
-        this->label1->Location = System::Drawing::Point(179, 21);
-        this->label1->Name = L"label1";
-        this->label1->Size = System::Drawing::Size(19, 12);
-        this->label1->TabIndex = 8;
-        this->label1->Text = L"α:";
-        // 
-        // label2
-        // 
-        this->label2->AutoSize = true;
-        this->label2->Location = System::Drawing::Point(177, 46);
-        this->label2->Name = L"label2";
-        this->label2->Size = System::Drawing::Size(19, 12);
-        this->label2->TabIndex = 9;
-        this->label2->Text = L"β:";
-        // 
-        // label3
-        // 
-        this->label3->AutoSize = true;
-        this->label3->Location = System::Drawing::Point(177, 71);
-        this->label3->Name = L"label3";
-        this->label3->Size = System::Drawing::Size(19, 12);
-        this->label3->TabIndex = 10;
-        this->label3->Text = L"γ:";
-        // 
-        // m_btn_undo
-        // 
-        this->m_btn_undo->Location = System::Drawing::Point(160, 398);
-        this->m_btn_undo->Margin = System::Windows::Forms::Padding(2);
-        this->m_btn_undo->Name = L"m_btn_undo";
-        this->m_btn_undo->Size = System::Drawing::Size(59, 23);
-        this->m_btn_undo->TabIndex = 11;
-        this->m_btn_undo->Text = L"UNDO";
-        this->m_btn_undo->UseVisualStyleBackColor = true;
-        this->m_btn_undo->Click += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_btn_undo_Click);
-        // 
-        // m_btn_copyfromprevframe
-        // 
-        this->m_btn_copyfromprevframe->Location = System::Drawing::Point(6, 61);
-        this->m_btn_copyfromprevframe->Margin = System::Windows::Forms::Padding(2);
-        this->m_btn_copyfromprevframe->Name = L"m_btn_copyfromprevframe";
-        this->m_btn_copyfromprevframe->Size = System::Drawing::Size(158, 26);
-        this->m_btn_copyfromprevframe->TabIndex = 13;
-        this->m_btn_copyfromprevframe->Text = L"Copy curves from pre_frame";
-        this->m_btn_copyfromprevframe->UseVisualStyleBackColor = true;
-        this->m_btn_copyfromprevframe->Click += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_btn_copyfromprevframe_Click);
-        // 
-        // m_radiobtn_movement
-        // 
-        this->m_radiobtn_movement->AutoSize = true;
-        this->m_radiobtn_movement->Checked = true;
-        this->m_radiobtn_movement->Location = System::Drawing::Point(6, 18);
-        this->m_radiobtn_movement->Name = L"m_radiobtn_movement";
-        this->m_radiobtn_movement->Size = System::Drawing::Size(80, 16);
-        this->m_radiobtn_movement->TabIndex = 14;
-        this->m_radiobtn_movement->TabStop = true;
-        this->m_radiobtn_movement->Text = L"Translation";
-        this->m_radiobtn_movement->UseVisualStyleBackColor = true;
-        this->m_radiobtn_movement->CheckedChanged += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_radiobtn_movement_CheckedChanged);
-        // 
-        // m_radiobtn_rotation
-        // 
-        this->m_radiobtn_rotation->AutoSize = true;
-        this->m_radiobtn_rotation->Location = System::Drawing::Point(6, 40);
-        this->m_radiobtn_rotation->Name = L"m_radiobtn_rotation";
-        this->m_radiobtn_rotation->Size = System::Drawing::Size(66, 16);
-        this->m_radiobtn_rotation->TabIndex = 15;
-        this->m_radiobtn_rotation->Text = L"Rotation";
-        this->m_radiobtn_rotation->UseVisualStyleBackColor = true;
-        this->m_radiobtn_rotation->CheckedChanged += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_radiobtn_rotation_CheckedChanged);
-        // 
-        // m_radiobtn_scaling
-        // 
-        this->m_radiobtn_scaling->AutoSize = true;
-        this->m_radiobtn_scaling->Location = System::Drawing::Point(6, 62);
-        this->m_radiobtn_scaling->Name = L"m_radiobtn_scaling";
-        this->m_radiobtn_scaling->Size = System::Drawing::Size(60, 16);
-        this->m_radiobtn_scaling->TabIndex = 16;
-        this->m_radiobtn_scaling->Text = L"Scaling";
-        this->m_radiobtn_scaling->UseVisualStyleBackColor = true;
-        this->m_radiobtn_scaling->CheckedChanged += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_radiobtn_scaling_CheckedChanged);
-        // 
-        // m_btn_sharestroke
-        // 
-        this->m_btn_sharestroke->Font = (gcnew System::Drawing::Font(L"MS UI Gothic", 9));
-        this->m_btn_sharestroke->Location = System::Drawing::Point(6, 90);
-        this->m_btn_sharestroke->Name = L"m_btn_sharestroke";
-        this->m_btn_sharestroke->Size = System::Drawing::Size(157, 27);
-        this->m_btn_sharestroke->TabIndex = 18;
-        this->m_btn_sharestroke->Text = L"Set as all frame curve\r\n";
-        this->m_btn_sharestroke->UseVisualStyleBackColor = true;
-        this->m_btn_sharestroke->Click += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_btn_sharestroke_Click);
-        // 
-        // m_radiobtn_stroke
-        // 
-        this->m_radiobtn_stroke->AutoSize = true;
-        this->m_radiobtn_stroke->Checked = true;
-        this->m_radiobtn_stroke->Location = System::Drawing::Point(6, 18);
-        this->m_radiobtn_stroke->Name = L"m_radiobtn_stroke";
-        this->m_radiobtn_stroke->Size = System::Drawing::Size(53, 16);
-        this->m_radiobtn_stroke->TabIndex = 20;
-        this->m_radiobtn_stroke->TabStop = true;
-        this->m_radiobtn_stroke->Text = L"Curve";
-        this->m_radiobtn_stroke->UseVisualStyleBackColor = true;
-        this->m_radiobtn_stroke->CheckedChanged += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_radiobtn_stroke_CheckedChanged);
-        // 
-        // m_radiobtn_cage
-        // 
-        this->m_radiobtn_cage->AutoSize = true;
-        this->m_radiobtn_cage->Location = System::Drawing::Point(67, 18);
-        this->m_radiobtn_cage->Name = L"m_radiobtn_cage";
-        this->m_radiobtn_cage->Size = System::Drawing::Size(49, 16);
-        this->m_radiobtn_cage->TabIndex = 21;
-        this->m_radiobtn_cage->Text = L"Cage";
-        this->m_radiobtn_cage->UseVisualStyleBackColor = true;
-        this->m_radiobtn_cage->CheckedChanged += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_radiobtn_cage_CheckedChanged);
-        // 
-        // groupBox1
-        // 
-        this->groupBox1->Controls->Add(this->m_radiobtn_movement);
-        this->groupBox1->Controls->Add(this->m_radiobtn_rotation);
-        this->groupBox1->Controls->Add(this->m_radiobtn_scaling);
-        this->groupBox1->Location = System::Drawing::Point(147, 71);
-        this->groupBox1->Name = L"groupBox1";
-        this->groupBox1->Size = System::Drawing::Size(117, 85);
-        this->groupBox1->TabIndex = 22;
-        this->groupBox1->TabStop = false;
-        this->groupBox1->Text = L"Transform mode";
-        // 
-        // groupBox2
-        // 
-        this->groupBox2->Controls->Add(this->m_radiobtn_cage);
-        this->groupBox2->Controls->Add(this->m_radiobtn_stroke);
-        this->groupBox2->Location = System::Drawing::Point(14, 71);
-        this->groupBox2->Name = L"groupBox2";
-        this->groupBox2->Size = System::Drawing::Size(127, 45);
-        this->groupBox2->TabIndex = 23;
-        this->groupBox2->TabStop = false;
-        this->groupBox2->Text = L"Deform mode";
-        // 
-        // m_numbox_cpsize
-        // 
-        this->m_numbox_cpsize->Font = (gcnew System::Drawing::Font(L"MS UI Gothic", 11.5F));
-        this->m_numbox_cpsize->Location = System::Drawing::Point(73, 126);
-        this->m_numbox_cpsize->Minimum = System::Decimal(gcnew cli::array< System::Int32 >(4) { 1, 0, 0, 0 });
-        this->m_numbox_cpsize->Name = L"m_numbox_cpsize";
-        this->m_numbox_cpsize->Size = System::Drawing::Size(57, 23);
-        this->m_numbox_cpsize->TabIndex = 24;
-        this->m_numbox_cpsize->TextAlign = System::Windows::Forms::HorizontalAlignment::Right;
-        this->m_numbox_cpsize->Value = System::Decimal(gcnew cli::array< System::Int32 >(4) { 10, 0, 0, 0 });
-        this->m_numbox_cpsize->ValueChanged += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_numbox_cpsize_ValueChanged);
-        // 
-        // label4
-        // 
-        this->label4->AutoSize = true;
-        this->label4->Location = System::Drawing::Point(21, 131);
-        this->label4->Name = L"label4";
-        this->label4->Size = System::Drawing::Size(46, 12);
-        this->label4->TabIndex = 25;
-        this->label4->Text = L"CP size:";
-        // 
-        // m_checkbox_showonlyselectedstroke
-        // 
-        this->m_checkbox_showonlyselectedstroke->AutoSize = true;
-        this->m_checkbox_showonlyselectedstroke->Font = (gcnew System::Drawing::Font(L"MS UI Gothic", 8));
-        this->m_checkbox_showonlyselectedstroke->Location = System::Drawing::Point(9, 123);
-        this->m_checkbox_showonlyselectedstroke->Name = L"m_checkbox_showonlyselectedstroke";
-        this->m_checkbox_showonlyselectedstroke->Size = System::Drawing::Size(148, 15);
-        this->m_checkbox_showonlyselectedstroke->TabIndex = 26;
-        this->m_checkbox_showonlyselectedstroke->Text = L"Show only selected stroke";
-        this->m_checkbox_showonlyselectedstroke->UseVisualStyleBackColor = true;
-        this->m_checkbox_showonlyselectedstroke->CheckedChanged += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_checkbox_showonlyselectedstroke_CheckedChanged);
-        // 
-        // m_btn_copycagetoallframes
-        // 
-        this->m_btn_copycagetoallframes->Location = System::Drawing::Point(14, 40);
-        this->m_btn_copycagetoallframes->Name = L"m_btn_copycagetoallframes";
-        this->m_btn_copycagetoallframes->Size = System::Drawing::Size(136, 23);
-        this->m_btn_copycagetoallframes->TabIndex = 27;
-        this->m_btn_copycagetoallframes->Text = L"Copy cage to all frames";
-        this->m_btn_copycagetoallframes->UseVisualStyleBackColor = true;
-        this->m_btn_copycagetoallframes->Click += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_btn_copycagetoallframes_Click);
-        // 
-        // groupBox3
-        // 
-        this->groupBox3->Controls->Add(this->label6);
-        this->groupBox3->Controls->Add(this->label5);
-        this->groupBox3->Controls->Add(this->m_btn_deform);
-        this->groupBox3->Controls->Add(this->m_btn_copyfromprevframe);
-        this->groupBox3->Controls->Add(this->m_checkbox_showonlyselectedstroke);
-        this->groupBox3->Controls->Add(this->m_btn_sharestroke);
-        this->groupBox3->Controls->Add(this->m_textbox_gamma);
-        this->groupBox3->Controls->Add(this->m_textbox_alpha);
-        this->groupBox3->Controls->Add(this->m_textbox_beta);
-        this->groupBox3->Controls->Add(this->label3);
-        this->groupBox3->Controls->Add(this->label2);
-        this->groupBox3->Controls->Add(this->label1);
-        this->groupBox3->Location = System::Drawing::Point(14, 162);
-        this->groupBox3->Name = L"groupBox3";
-        this->groupBox3->Size = System::Drawing::Size(252, 231);
-        this->groupBox3->TabIndex = 28;
-        this->groupBox3->TabStop = false;
-        this->groupBox3->Text = L"Stroke ＆ Deformation";
-        // 
-        // label6
-        // 
-        this->label6->AutoSize = true;
-        this->label6->Font = (gcnew System::Drawing::Font(L"ＭＳ ゴシック", 9, System::Drawing::FontStyle::Regular, System::Drawing::GraphicsUnit::Point,
-            static_cast<System::Byte>(128)));
-        this->label6->Location = System::Drawing::Point(10, 185);
-        this->label6->Name = L"label6";
-        this->label6->Size = System::Drawing::Size(179, 36);
-        this->label6->TabIndex = 29;
-        this->label6->Text = L"Shift + 左 click - 制御点追加\r\nShift + 左 drag - 制御点移動 \r\nShift + 右 down - 制御点削除\r\n";
-        // 
-        // label5
-        // 
-        this->label5->AutoSize = true;
-        this->label5->Font = (gcnew System::Drawing::Font(L"ＭＳ ゴシック", 9, System::Drawing::FontStyle::Regular, System::Drawing::GraphicsUnit::Point,
-            static_cast<System::Byte>(128)));
-        this->label5->Location = System::Drawing::Point(11, 141);
-        this->label5->Name = L"label5";
-        this->label5->Size = System::Drawing::Size(137, 36);
-        this->label5->TabIndex = 29;
-        this->label5->Text = L"　 赤: 選択中のcurve\r\n　 黄: 未選択のcurve\r\n緑/青: all frame curve";
-        // 
-        // m_btn_finish_segmentation
-        // 
-        this->m_btn_finish_segmentation->Font = (gcnew System::Drawing::Font(L"MS UI Gothic", 11.25F, System::Drawing::FontStyle::Bold, System::Drawing::GraphicsUnit::Point,
-            static_cast<System::Byte>(128)));
-        this->m_btn_finish_segmentation->Location = System::Drawing::Point(12, 464);
-        this->m_btn_finish_segmentation->Margin = System::Windows::Forms::Padding(2);
-        this->m_btn_finish_segmentation->Name = L"m_btn_finish_segmentation";
-        this->m_btn_finish_segmentation->Size = System::Drawing::Size(191, 32);
-        this->m_btn_finish_segmentation->TabIndex = 29;
-        this->m_btn_finish_segmentation->Text = L"Finish And Store ROI";
-        this->m_btn_finish_segmentation->UseVisualStyleBackColor = true;
-        this->m_btn_finish_segmentation->Click += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_btn_finish_segmentation_Click);
-        // 
-        // FormSegStrokeFfd
-        // 
-        this->AutoScaleDimensions = System::Drawing::SizeF(6, 12);
-        this->AutoScaleMode = System::Windows::Forms::AutoScaleMode::Font;
-        this->ClientSize = System::Drawing::Size(278, 507);
-        this->Controls->Add(this->m_btn_finish_segmentation);
-        this->Controls->Add(this->groupBox3);
-        this->Controls->Add(this->m_btn_copycagetoallframes);
-        this->Controls->Add(this->label4);
-        this->Controls->Add(this->m_numbox_cpsize);
-        this->Controls->Add(this->groupBox2);
-        this->Controls->Add(this->m_btn_savestate);
-        this->Controls->Add(this->groupBox1);
-        this->Controls->Add(this->m_btn_loadstate);
-        this->Controls->Add(this->m_btn_undo);
-        this->Controls->Add(this->m_btn_savemeshandcage);
-        this->Controls->Add(this->m_btn_loadmeshandcage);
-        this->Name = L"FormSegStrokeFfd";
-        this->Text = L"FormSegStrokeFfd";
-        this->groupBox1->ResumeLayout(false);
-        this->groupBox1->PerformLayout();
-        this->groupBox2->ResumeLayout(false);
-        this->groupBox2->PerformLayout();
-        (cli::safe_cast<System::ComponentModel::ISupportInitialize^>(this->m_numbox_cpsize))->EndInit();
-        this->groupBox3->ResumeLayout(false);
-        this->groupBox3->PerformLayout();
-        this->ResumeLayout(false);
-        this->PerformLayout();
+      this->m_btn_loadmeshandcage = (gcnew System::Windows::Forms::Button());
+      this->m_btn_savemeshandcage = (gcnew System::Windows::Forms::Button());
+      this->m_btn_loadstate = (gcnew System::Windows::Forms::Button());
+      this->m_btn_savestate = (gcnew System::Windows::Forms::Button());
+      this->m_textbox_alpha = (gcnew System::Windows::Forms::TextBox());
+      this->m_textbox_beta = (gcnew System::Windows::Forms::TextBox());
+      this->m_textbox_gamma = (gcnew System::Windows::Forms::TextBox());
+      this->m_btn_deform = (gcnew System::Windows::Forms::Button());
+      this->m_btn_flipnormal = (gcnew System::Windows::Forms::Button());
+      this->label1 = (gcnew System::Windows::Forms::Label());
+      this->label2 = (gcnew System::Windows::Forms::Label());
+      this->label3 = (gcnew System::Windows::Forms::Label());
+      this->m_btn_undo = (gcnew System::Windows::Forms::Button());
+      this->m_btn_copyfromprevframe = (gcnew System::Windows::Forms::Button());
+      this->m_radiobtn_movement = (gcnew System::Windows::Forms::RadioButton());
+      this->m_radiobtn_rotation = (gcnew System::Windows::Forms::RadioButton());
+      this->m_radiobtn_scaling = (gcnew System::Windows::Forms::RadioButton());
+      this->m_btn_sharestroke = (gcnew System::Windows::Forms::Button());
+      this->m_radiobtn_stroke = (gcnew System::Windows::Forms::RadioButton());
+      this->m_radiobtn_cage = (gcnew System::Windows::Forms::RadioButton());
+      this->groupBox1 = (gcnew System::Windows::Forms::GroupBox());
+      this->groupBox2 = (gcnew System::Windows::Forms::GroupBox());
+      this->m_numbox_cpsize = (gcnew System::Windows::Forms::NumericUpDown());
+      this->label4 = (gcnew System::Windows::Forms::Label());
+      this->m_checkbox_showonlyselectedstroke = (gcnew System::Windows::Forms::CheckBox());
+      this->m_btn_copycagetoallframes = (gcnew System::Windows::Forms::Button());
+      this->groupBox3 = (gcnew System::Windows::Forms::GroupBox());
+      this->label6 = (gcnew System::Windows::Forms::Label());
+      this->label5 = (gcnew System::Windows::Forms::Label());
+      this->m_btn_finish_segmentation = (gcnew System::Windows::Forms::Button());
+      this->groupBox1->SuspendLayout();
+      this->groupBox2->SuspendLayout();
+      (cli::safe_cast<System::ComponentModel::ISupportInitialize^>(this->m_numbox_cpsize))->BeginInit();
+      this->groupBox3->SuspendLayout();
+      this->SuspendLayout();
+      // 
+      // m_btn_loadmeshandcage
+      // 
+      this->m_btn_loadmeshandcage->Location = System::Drawing::Point(12, 12);
+      this->m_btn_loadmeshandcage->Name = L"m_btn_loadmeshandcage";
+      this->m_btn_loadmeshandcage->Size = System::Drawing::Size(138, 23);
+      this->m_btn_loadmeshandcage->TabIndex = 0;
+      this->m_btn_loadmeshandcage->Text = L"Import mesh＆cage";
+      this->m_btn_loadmeshandcage->UseVisualStyleBackColor = true;
+      this->m_btn_loadmeshandcage->Click += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_btn_loadmeshandcage_Click);
+      // 
+      // m_btn_savemeshandcage
+      // 
+      this->m_btn_savemeshandcage->Location = System::Drawing::Point(153, 12);
+      this->m_btn_savemeshandcage->Margin = System::Windows::Forms::Padding(2);
+      this->m_btn_savemeshandcage->Name = L"m_btn_savemeshandcage";
+      this->m_btn_savemeshandcage->Size = System::Drawing::Size(120, 23);
+      this->m_btn_savemeshandcage->TabIndex = 1;
+      this->m_btn_savemeshandcage->Text = L"Export mesh＆cage";
+      this->m_btn_savemeshandcage->UseVisualStyleBackColor = true;
+      this->m_btn_savemeshandcage->Click += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_btn_savemeshandcage_Click);
+      // 
+      // m_btn_loadstate
+      // 
+      this->m_btn_loadstate->Location = System::Drawing::Point(14, 437);
+      this->m_btn_loadstate->Margin = System::Windows::Forms::Padding(2);
+      this->m_btn_loadstate->Name = L"m_btn_loadstate";
+      this->m_btn_loadstate->Size = System::Drawing::Size(142, 23);
+      this->m_btn_loadstate->TabIndex = 2;
+      this->m_btn_loadstate->Text = L"Load cage and curves";
+      this->m_btn_loadstate->UseVisualStyleBackColor = true;
+      this->m_btn_loadstate->Click += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_btn_loadstate_Click);
+      // 
+      // m_btn_savestate
+      // 
+      this->m_btn_savestate->Location = System::Drawing::Point(14, 410);
+      this->m_btn_savestate->Margin = System::Windows::Forms::Padding(2);
+      this->m_btn_savestate->Name = L"m_btn_savestate";
+      this->m_btn_savestate->Size = System::Drawing::Size(142, 23);
+      this->m_btn_savestate->TabIndex = 3;
+      this->m_btn_savestate->Text = L"Save Cage and curves";
+      this->m_btn_savestate->UseVisualStyleBackColor = true;
+      this->m_btn_savestate->Click += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_btn_savestate_Click);
+      // 
+      // m_textbox_alpha
+      // 
+      this->m_textbox_alpha->Location = System::Drawing::Point(199, 18);
+      this->m_textbox_alpha->Name = L"m_textbox_alpha";
+      this->m_textbox_alpha->Size = System::Drawing::Size(38, 19);
+      this->m_textbox_alpha->TabIndex = 4;
+      this->m_textbox_alpha->Text = L"1.0";
+      // 
+      // m_textbox_beta
+      // 
+      this->m_textbox_beta->Location = System::Drawing::Point(199, 43);
+      this->m_textbox_beta->Name = L"m_textbox_beta";
+      this->m_textbox_beta->Size = System::Drawing::Size(38, 19);
+      this->m_textbox_beta->TabIndex = 5;
+      this->m_textbox_beta->Text = L"1.0";
+      // 
+      // m_textbox_gamma
+      // 
+      this->m_textbox_gamma->Location = System::Drawing::Point(199, 68);
+      this->m_textbox_gamma->Name = L"m_textbox_gamma";
+      this->m_textbox_gamma->Size = System::Drawing::Size(38, 19);
+      this->m_textbox_gamma->TabIndex = 6;
+      this->m_textbox_gamma->Text = L"5.0";
+      // 
+      // m_btn_deform
+      // 
+      this->m_btn_deform->Location = System::Drawing::Point(6, 17);
+      this->m_btn_deform->Margin = System::Windows::Forms::Padding(2);
+      this->m_btn_deform->Name = L"m_btn_deform";
+      this->m_btn_deform->Size = System::Drawing::Size(157, 32);
+      this->m_btn_deform->TabIndex = 7;
+      this->m_btn_deform->Text = L"Deform (変形を計算)";
+      this->m_btn_deform->UseVisualStyleBackColor = true;
+      this->m_btn_deform->Click += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_btn_deform_Click);
+      // 
+      // m_btn_flipnormal
+      // 
+      this->m_btn_flipnormal->Location = System::Drawing::Point(6, 115);
+      this->m_btn_flipnormal->Name = L"m_btn_flipnormal";
+      this->m_btn_flipnormal->Size = System::Drawing::Size(157, 23);
+      this->m_btn_flipnormal->TabIndex = 30;
+      this->m_btn_flipnormal->Text = L"Flip Normals";
+      this->m_btn_flipnormal->UseVisualStyleBackColor = true;
+      this->m_btn_flipnormal->Click += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_btn_flipnormal_Click);
+      // 
+      // label1
+      // 
+      this->label1->AutoSize = true;
+      this->label1->Location = System::Drawing::Point(179, 21);
+      this->label1->Name = L"label1";
+      this->label1->Size = System::Drawing::Size(19, 12);
+      this->label1->TabIndex = 8;
+      this->label1->Text = L"α:";
+      // 
+      // label2
+      // 
+      this->label2->AutoSize = true;
+      this->label2->Location = System::Drawing::Point(177, 46);
+      this->label2->Name = L"label2";
+      this->label2->Size = System::Drawing::Size(19, 12);
+      this->label2->TabIndex = 9;
+      this->label2->Text = L"β:";
+      // 
+      // label3
+      // 
+      this->label3->AutoSize = true;
+      this->label3->Location = System::Drawing::Point(177, 71);
+      this->label3->Name = L"label3";
+      this->label3->Size = System::Drawing::Size(19, 12);
+      this->label3->TabIndex = 10;
+      this->label3->Text = L"γ:";
+      // 
+      // m_btn_undo
+      // 
+      this->m_btn_undo->Location = System::Drawing::Point(160, 410);
+      this->m_btn_undo->Margin = System::Windows::Forms::Padding(2);
+      this->m_btn_undo->Name = L"m_btn_undo";
+      this->m_btn_undo->Size = System::Drawing::Size(59, 23);
+      this->m_btn_undo->TabIndex = 11;
+      this->m_btn_undo->Text = L"UNDO";
+      this->m_btn_undo->UseVisualStyleBackColor = true;
+      this->m_btn_undo->Click += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_btn_undo_Click);
+      // 
+      // m_btn_copyfromprevframe
+      // 
+      this->m_btn_copyfromprevframe->Location = System::Drawing::Point(5, 53);
+      this->m_btn_copyfromprevframe->Margin = System::Windows::Forms::Padding(2);
+      this->m_btn_copyfromprevframe->Name = L"m_btn_copyfromprevframe";
+      this->m_btn_copyfromprevframe->Size = System::Drawing::Size(158, 26);
+      this->m_btn_copyfromprevframe->TabIndex = 13;
+      this->m_btn_copyfromprevframe->Text = L"Copy curves from pre_frame";
+      this->m_btn_copyfromprevframe->UseVisualStyleBackColor = true;
+      this->m_btn_copyfromprevframe->Click += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_btn_copyfromprevframe_Click);
+      // 
+      // m_radiobtn_movement
+      // 
+      this->m_radiobtn_movement->AutoSize = true;
+      this->m_radiobtn_movement->Checked = true;
+      this->m_radiobtn_movement->Location = System::Drawing::Point(6, 18);
+      this->m_radiobtn_movement->Name = L"m_radiobtn_movement";
+      this->m_radiobtn_movement->Size = System::Drawing::Size(80, 16);
+      this->m_radiobtn_movement->TabIndex = 14;
+      this->m_radiobtn_movement->TabStop = true;
+      this->m_radiobtn_movement->Text = L"Translation";
+      this->m_radiobtn_movement->UseVisualStyleBackColor = true;
+      this->m_radiobtn_movement->CheckedChanged += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_radiobtn_movement_CheckedChanged);
+      // 
+      // m_radiobtn_rotation
+      // 
+      this->m_radiobtn_rotation->AutoSize = true;
+      this->m_radiobtn_rotation->Location = System::Drawing::Point(6, 40);
+      this->m_radiobtn_rotation->Name = L"m_radiobtn_rotation";
+      this->m_radiobtn_rotation->Size = System::Drawing::Size(66, 16);
+      this->m_radiobtn_rotation->TabIndex = 15;
+      this->m_radiobtn_rotation->Text = L"Rotation";
+      this->m_radiobtn_rotation->UseVisualStyleBackColor = true;
+      this->m_radiobtn_rotation->CheckedChanged += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_radiobtn_rotation_CheckedChanged);
+      // 
+      // m_radiobtn_scaling
+      // 
+      this->m_radiobtn_scaling->AutoSize = true;
+      this->m_radiobtn_scaling->Location = System::Drawing::Point(6, 62);
+      this->m_radiobtn_scaling->Name = L"m_radiobtn_scaling";
+      this->m_radiobtn_scaling->Size = System::Drawing::Size(60, 16);
+      this->m_radiobtn_scaling->TabIndex = 16;
+      this->m_radiobtn_scaling->Text = L"Scaling";
+      this->m_radiobtn_scaling->UseVisualStyleBackColor = true;
+      this->m_radiobtn_scaling->CheckedChanged += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_radiobtn_scaling_CheckedChanged);
+      // 
+      // m_btn_sharestroke
+      // 
+      this->m_btn_sharestroke->Font = (gcnew System::Drawing::Font(L"MS UI Gothic", 9));
+      this->m_btn_sharestroke->Location = System::Drawing::Point(6, 84);
+      this->m_btn_sharestroke->Name = L"m_btn_sharestroke";
+      this->m_btn_sharestroke->Size = System::Drawing::Size(157, 27);
+      this->m_btn_sharestroke->TabIndex = 18;
+      this->m_btn_sharestroke->Text = L"Set as all frame curve\r\n";
+      this->m_btn_sharestroke->UseVisualStyleBackColor = true;
+      this->m_btn_sharestroke->Click += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_btn_sharestroke_Click);
+      // 
+      // m_radiobtn_stroke
+      // 
+      this->m_radiobtn_stroke->AutoSize = true;
+      this->m_radiobtn_stroke->Checked = true;
+      this->m_radiobtn_stroke->Location = System::Drawing::Point(6, 18);
+      this->m_radiobtn_stroke->Name = L"m_radiobtn_stroke";
+      this->m_radiobtn_stroke->Size = System::Drawing::Size(53, 16);
+      this->m_radiobtn_stroke->TabIndex = 20;
+      this->m_radiobtn_stroke->TabStop = true;
+      this->m_radiobtn_stroke->Text = L"Curve";
+      this->m_radiobtn_stroke->UseVisualStyleBackColor = true;
+      this->m_radiobtn_stroke->CheckedChanged += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_radiobtn_stroke_CheckedChanged);
+      // 
+      // m_radiobtn_cage
+      // 
+      this->m_radiobtn_cage->AutoSize = true;
+      this->m_radiobtn_cage->Location = System::Drawing::Point(67, 18);
+      this->m_radiobtn_cage->Name = L"m_radiobtn_cage";
+      this->m_radiobtn_cage->Size = System::Drawing::Size(49, 16);
+      this->m_radiobtn_cage->TabIndex = 21;
+      this->m_radiobtn_cage->Text = L"Cage";
+      this->m_radiobtn_cage->UseVisualStyleBackColor = true;
+      this->m_radiobtn_cage->CheckedChanged += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_radiobtn_cage_CheckedChanged);
+      // 
+      // groupBox1
+      // 
+      this->groupBox1->Controls->Add(this->m_radiobtn_movement);
+      this->groupBox1->Controls->Add(this->m_radiobtn_rotation);
+      this->groupBox1->Controls->Add(this->m_radiobtn_scaling);
+      this->groupBox1->Location = System::Drawing::Point(147, 71);
+      this->groupBox1->Name = L"groupBox1";
+      this->groupBox1->Size = System::Drawing::Size(117, 85);
+      this->groupBox1->TabIndex = 22;
+      this->groupBox1->TabStop = false;
+      this->groupBox1->Text = L"Transform mode";
+      // 
+      // groupBox2
+      // 
+      this->groupBox2->Controls->Add(this->m_radiobtn_cage);
+      this->groupBox2->Controls->Add(this->m_radiobtn_stroke);
+      this->groupBox2->Location = System::Drawing::Point(14, 71);
+      this->groupBox2->Name = L"groupBox2";
+      this->groupBox2->Size = System::Drawing::Size(127, 45);
+      this->groupBox2->TabIndex = 23;
+      this->groupBox2->TabStop = false;
+      this->groupBox2->Text = L"Deform mode";
+      // 
+      // m_numbox_cpsize
+      // 
+      this->m_numbox_cpsize->Font = (gcnew System::Drawing::Font(L"MS UI Gothic", 11.5F));
+      this->m_numbox_cpsize->Location = System::Drawing::Point(73, 126);
+      this->m_numbox_cpsize->Minimum = System::Decimal(gcnew cli::array< System::Int32 >(4) { 1, 0, 0, 0 });
+      this->m_numbox_cpsize->Name = L"m_numbox_cpsize";
+      this->m_numbox_cpsize->Size = System::Drawing::Size(57, 23);
+      this->m_numbox_cpsize->TabIndex = 24;
+      this->m_numbox_cpsize->TextAlign = System::Windows::Forms::HorizontalAlignment::Right;
+      this->m_numbox_cpsize->Value = System::Decimal(gcnew cli::array< System::Int32 >(4) { 10, 0, 0, 0 });
+      this->m_numbox_cpsize->ValueChanged += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_numbox_cpsize_ValueChanged);
+      // 
+      // label4
+      // 
+      this->label4->AutoSize = true;
+      this->label4->Location = System::Drawing::Point(21, 131);
+      this->label4->Name = L"label4";
+      this->label4->Size = System::Drawing::Size(46, 12);
+      this->label4->TabIndex = 25;
+      this->label4->Text = L"CP size:";
+      // 
+      // m_checkbox_showonlyselectedstroke
+      // 
+      this->m_checkbox_showonlyselectedstroke->AutoSize = true;
+      this->m_checkbox_showonlyselectedstroke->Font = (gcnew System::Drawing::Font(L"MS UI Gothic", 8));
+      this->m_checkbox_showonlyselectedstroke->Location = System::Drawing::Point(9, 141);
+      this->m_checkbox_showonlyselectedstroke->Name = L"m_checkbox_showonlyselectedstroke";
+      this->m_checkbox_showonlyselectedstroke->Size = System::Drawing::Size(148, 15);
+      this->m_checkbox_showonlyselectedstroke->TabIndex = 26;
+      this->m_checkbox_showonlyselectedstroke->Text = L"Show only selected stroke";
+      this->m_checkbox_showonlyselectedstroke->UseVisualStyleBackColor = true;
+      this->m_checkbox_showonlyselectedstroke->CheckedChanged += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_checkbox_showonlyselectedstroke_CheckedChanged);
+      // 
+      // m_btn_copycagetoallframes
+      // 
+      this->m_btn_copycagetoallframes->Location = System::Drawing::Point(14, 40);
+      this->m_btn_copycagetoallframes->Name = L"m_btn_copycagetoallframes";
+      this->m_btn_copycagetoallframes->Size = System::Drawing::Size(136, 23);
+      this->m_btn_copycagetoallframes->TabIndex = 27;
+      this->m_btn_copycagetoallframes->Text = L"Copy cage to all frames";
+      this->m_btn_copycagetoallframes->UseVisualStyleBackColor = true;
+      this->m_btn_copycagetoallframes->Click += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_btn_copycagetoallframes_Click);
+      // 
+      // groupBox3
+      // 
+      this->groupBox3->Controls->Add(this->label6);
+      this->groupBox3->Controls->Add(this->label5);
+      this->groupBox3->Controls->Add(this->m_btn_deform);
+      this->groupBox3->Controls->Add(this->m_btn_copyfromprevframe);
+      this->groupBox3->Controls->Add(this->m_checkbox_showonlyselectedstroke);
+      this->groupBox3->Controls->Add(this->m_btn_sharestroke);
+      this->groupBox3->Controls->Add(this->m_btn_flipnormal);
+      this->groupBox3->Controls->Add(this->m_textbox_gamma);
+      this->groupBox3->Controls->Add(this->m_textbox_alpha);
+      this->groupBox3->Controls->Add(this->m_textbox_beta);
+      this->groupBox3->Controls->Add(this->label3);
+      this->groupBox3->Controls->Add(this->label2);
+      this->groupBox3->Controls->Add(this->label1);
+      this->groupBox3->Location = System::Drawing::Point(14, 162);
+      this->groupBox3->Name = L"groupBox3";
+      this->groupBox3->Size = System::Drawing::Size(252, 243);
+      this->groupBox3->TabIndex = 28;
+      this->groupBox3->TabStop = false;
+      this->groupBox3->Text = L"Stroke ＆ Deformation";
+      // 
+      // label6
+      // 
+      this->label6->AutoSize = true;
+      this->label6->Font = (gcnew System::Drawing::Font(L"ＭＳ ゴシック", 9, System::Drawing::FontStyle::Regular, System::Drawing::GraphicsUnit::Point,
+        static_cast<System::Byte>(128)));
+      this->label6->Location = System::Drawing::Point(7, 204);
+      this->label6->Name = L"label6";
+      this->label6->Size = System::Drawing::Size(179, 36);
+      this->label6->TabIndex = 29;
+      this->label6->Text = L"Shift + 左 click - 制御点追加\r\nShift + 左 drag - 制御点移動 \r\nShift + 右 down - 制御点削除\r\n";
+      // 
+      // label5
+      // 
+      this->label5->AutoSize = true;
+      this->label5->Font = (gcnew System::Drawing::Font(L"ＭＳ ゴシック", 9, System::Drawing::FontStyle::Regular, System::Drawing::GraphicsUnit::Point,
+        static_cast<System::Byte>(128)));
+      this->label5->Location = System::Drawing::Point(7, 159);
+      this->label5->Name = L"label5";
+      this->label5->Size = System::Drawing::Size(137, 36);
+      this->label5->TabIndex = 29;
+      this->label5->Text = L"　 赤: 選択中のcurve\r\n　 黄: 未選択のcurve\r\n緑/青: all frame curve";
+      // 
+      // m_btn_finish_segmentation
+      // 
+      this->m_btn_finish_segmentation->Font = (gcnew System::Drawing::Font(L"MS UI Gothic", 11.25F, System::Drawing::FontStyle::Bold, System::Drawing::GraphicsUnit::Point,
+        static_cast<System::Byte>(128)));
+      this->m_btn_finish_segmentation->Location = System::Drawing::Point(12, 464);
+      this->m_btn_finish_segmentation->Margin = System::Windows::Forms::Padding(2);
+      this->m_btn_finish_segmentation->Name = L"m_btn_finish_segmentation";
+      this->m_btn_finish_segmentation->Size = System::Drawing::Size(191, 32);
+      this->m_btn_finish_segmentation->TabIndex = 29;
+      this->m_btn_finish_segmentation->Text = L"Finish And Store ROI";
+      this->m_btn_finish_segmentation->UseVisualStyleBackColor = true;
+      this->m_btn_finish_segmentation->Click += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_btn_finish_segmentation_Click);
+      // 
+      // FormSegStrokeFfd
+      // 
+      this->AutoScaleDimensions = System::Drawing::SizeF(6, 12);
+      this->AutoScaleMode = System::Windows::Forms::AutoScaleMode::Font;
+      this->ClientSize = System::Drawing::Size(278, 507);
+      this->Controls->Add(this->m_btn_finish_segmentation);
+      this->Controls->Add(this->groupBox3);
+      this->Controls->Add(this->m_btn_copycagetoallframes);
+      this->Controls->Add(this->label4);
+      this->Controls->Add(this->m_numbox_cpsize);
+      this->Controls->Add(this->groupBox2);
+      this->Controls->Add(this->m_btn_savestate);
+      this->Controls->Add(this->groupBox1);
+      this->Controls->Add(this->m_btn_loadstate);
+      this->Controls->Add(this->m_btn_undo);
+      this->Controls->Add(this->m_btn_savemeshandcage);
+      this->Controls->Add(this->m_btn_loadmeshandcage);
+      this->Name = L"FormSegStrokeFfd";
+      this->Text = L"FormSegStrokeFfd";
+      this->groupBox1->ResumeLayout(false);
+      this->groupBox1->PerformLayout();
+      this->groupBox2->ResumeLayout(false);
+      this->groupBox2->PerformLayout();
+      (cli::safe_cast<System::ComponentModel::ISupportInitialize^>(this->m_numbox_cpsize))->EndInit();
+      this->groupBox3->ResumeLayout(false);
+      this->groupBox3->PerformLayout();
+      this->ResumeLayout(false);
+      this->PerformLayout();
 
     }
 #pragma endregion
@@ -489,6 +502,7 @@ namespace RoiPainter4D {
     System::Void m_btn_copyfromprevframe_Click(System::Object^ sender, System::EventArgs^ e);
     System::Void m_btn_finish_segmentation_Click(System::Object^ sender, System::EventArgs^ e);
     System::Void m_btn_sharestroke_Click(System::Object^ sender, System::EventArgs^ e);
+    System::Void m_btn_flipnormal_Click(System::Object^ sender, System::EventArgs^ e);
     System::Void m_btn_copycagetoallframes_Click(System::Object^ sender, System::EventArgs^ e);
     System::Void m_radiobtn_stroke_CheckedChanged(System::Object^ sender, System::EventArgs^ e);
     System::Void m_radiobtn_cage_CheckedChanged(System::Object^ sender, System::EventArgs^ e);

--- a/RoiPainter4D/RoiPainter4D/FormSegStrokeFfd.h
+++ b/RoiPainter4D/RoiPainter4D/FormSegStrokeFfd.h
@@ -154,7 +154,7 @@ namespace RoiPainter4D {
       // 
       // m_btn_loadstate
       // 
-      this->m_btn_loadstate->Location = System::Drawing::Point(14, 437);
+      this->m_btn_loadstate->Location = System::Drawing::Point(14, 446);
       this->m_btn_loadstate->Margin = System::Windows::Forms::Padding(2);
       this->m_btn_loadstate->Name = L"m_btn_loadstate";
       this->m_btn_loadstate->Size = System::Drawing::Size(142, 23);
@@ -165,7 +165,7 @@ namespace RoiPainter4D {
       // 
       // m_btn_savestate
       // 
-      this->m_btn_savestate->Location = System::Drawing::Point(14, 410);
+      this->m_btn_savestate->Location = System::Drawing::Point(14, 419);
       this->m_btn_savestate->Margin = System::Windows::Forms::Padding(2);
       this->m_btn_savestate->Name = L"m_btn_savestate";
       this->m_btn_savestate->Size = System::Drawing::Size(142, 23);
@@ -211,11 +211,11 @@ namespace RoiPainter4D {
       // 
       // m_btn_flipnormal
       // 
-      this->m_btn_flipnormal->Location = System::Drawing::Point(6, 115);
+      this->m_btn_flipnormal->Location = System::Drawing::Point(6, 117);
       this->m_btn_flipnormal->Name = L"m_btn_flipnormal";
       this->m_btn_flipnormal->Size = System::Drawing::Size(157, 23);
       this->m_btn_flipnormal->TabIndex = 30;
-      this->m_btn_flipnormal->Text = L"Flip Normals";
+      this->m_btn_flipnormal->Text = L"Flip normals";
       this->m_btn_flipnormal->UseVisualStyleBackColor = true;
       this->m_btn_flipnormal->Click += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_btn_flipnormal_Click);
       // 
@@ -248,7 +248,7 @@ namespace RoiPainter4D {
       // 
       // m_btn_undo
       // 
-      this->m_btn_undo->Location = System::Drawing::Point(160, 410);
+      this->m_btn_undo->Location = System::Drawing::Point(160, 419);
       this->m_btn_undo->Margin = System::Windows::Forms::Padding(2);
       this->m_btn_undo->Name = L"m_btn_undo";
       this->m_btn_undo->Size = System::Drawing::Size(59, 23);
@@ -259,10 +259,10 @@ namespace RoiPainter4D {
       // 
       // m_btn_copyfromprevframe
       // 
-      this->m_btn_copyfromprevframe->Location = System::Drawing::Point(5, 53);
+      this->m_btn_copyfromprevframe->Location = System::Drawing::Point(6, 86);
       this->m_btn_copyfromprevframe->Margin = System::Windows::Forms::Padding(2);
       this->m_btn_copyfromprevframe->Name = L"m_btn_copyfromprevframe";
-      this->m_btn_copyfromprevframe->Size = System::Drawing::Size(158, 26);
+      this->m_btn_copyfromprevframe->Size = System::Drawing::Size(157, 26);
       this->m_btn_copyfromprevframe->TabIndex = 13;
       this->m_btn_copyfromprevframe->Text = L"Copy curves from pre_frame";
       this->m_btn_copyfromprevframe->UseVisualStyleBackColor = true;
@@ -306,7 +306,7 @@ namespace RoiPainter4D {
       // m_btn_sharestroke
       // 
       this->m_btn_sharestroke->Font = (gcnew System::Drawing::Font(L"MS UI Gothic", 9));
-      this->m_btn_sharestroke->Location = System::Drawing::Point(6, 84);
+      this->m_btn_sharestroke->Location = System::Drawing::Point(6, 54);
       this->m_btn_sharestroke->Name = L"m_btn_sharestroke";
       this->m_btn_sharestroke->Size = System::Drawing::Size(157, 27);
       this->m_btn_sharestroke->TabIndex = 18;
@@ -386,7 +386,7 @@ namespace RoiPainter4D {
       // 
       this->m_checkbox_showonlyselectedstroke->AutoSize = true;
       this->m_checkbox_showonlyselectedstroke->Font = (gcnew System::Drawing::Font(L"MS UI Gothic", 8));
-      this->m_checkbox_showonlyselectedstroke->Location = System::Drawing::Point(9, 141);
+      this->m_checkbox_showonlyselectedstroke->Location = System::Drawing::Point(9, 146);
       this->m_checkbox_showonlyselectedstroke->Name = L"m_checkbox_showonlyselectedstroke";
       this->m_checkbox_showonlyselectedstroke->Size = System::Drawing::Size(148, 15);
       this->m_checkbox_showonlyselectedstroke->TabIndex = 26;
@@ -421,7 +421,7 @@ namespace RoiPainter4D {
       this->groupBox3->Controls->Add(this->label1);
       this->groupBox3->Location = System::Drawing::Point(14, 162);
       this->groupBox3->Name = L"groupBox3";
-      this->groupBox3->Size = System::Drawing::Size(252, 243);
+      this->groupBox3->Size = System::Drawing::Size(252, 252);
       this->groupBox3->TabIndex = 28;
       this->groupBox3->TabStop = false;
       this->groupBox3->Text = L"Stroke ＆ Deformation";
@@ -431,7 +431,7 @@ namespace RoiPainter4D {
       this->label6->AutoSize = true;
       this->label6->Font = (gcnew System::Drawing::Font(L"ＭＳ ゴシック", 9, System::Drawing::FontStyle::Regular, System::Drawing::GraphicsUnit::Point,
         static_cast<System::Byte>(128)));
-      this->label6->Location = System::Drawing::Point(7, 204);
+      this->label6->Location = System::Drawing::Point(7, 213);
       this->label6->Name = L"label6";
       this->label6->Size = System::Drawing::Size(179, 36);
       this->label6->TabIndex = 29;
@@ -442,7 +442,7 @@ namespace RoiPainter4D {
       this->label5->AutoSize = true;
       this->label5->Font = (gcnew System::Drawing::Font(L"ＭＳ ゴシック", 9, System::Drawing::FontStyle::Regular, System::Drawing::GraphicsUnit::Point,
         static_cast<System::Byte>(128)));
-      this->label5->Location = System::Drawing::Point(7, 159);
+      this->label5->Location = System::Drawing::Point(7, 168);
       this->label5->Name = L"label5";
       this->label5->Size = System::Drawing::Size(137, 36);
       this->label5->TabIndex = 29;
@@ -452,7 +452,7 @@ namespace RoiPainter4D {
       // 
       this->m_btn_finish_segmentation->Font = (gcnew System::Drawing::Font(L"MS UI Gothic", 11.25F, System::Drawing::FontStyle::Bold, System::Drawing::GraphicsUnit::Point,
         static_cast<System::Byte>(128)));
-      this->m_btn_finish_segmentation->Location = System::Drawing::Point(12, 464);
+      this->m_btn_finish_segmentation->Location = System::Drawing::Point(14, 473);
       this->m_btn_finish_segmentation->Margin = System::Windows::Forms::Padding(2);
       this->m_btn_finish_segmentation->Name = L"m_btn_finish_segmentation";
       this->m_btn_finish_segmentation->Size = System::Drawing::Size(191, 32);
@@ -480,6 +480,7 @@ namespace RoiPainter4D {
       this->Controls->Add(this->m_btn_loadmeshandcage);
       this->Name = L"FormSegStrokeFfd";
       this->Text = L"FormSegStrokeFfd";
+      this->Load += gcnew System::EventHandler(this, &FormSegStrokeFfd::FormSegStrokeFfd_Load);
       this->groupBox1->ResumeLayout(false);
       this->groupBox1->PerformLayout();
       this->groupBox2->ResumeLayout(false);
@@ -525,6 +526,8 @@ namespace RoiPainter4D {
     void FrameChanged();
     int GetCpSize(){ return (int)(this->m_numbox_cpsize->Value); }
 
+private: System::Void FormSegStrokeFfd_Load(System::Object^ sender, System::EventArgs^ e) {
+}
 };
   
   enum SFFD_MODE{ SFFD_STROKE, SFFD_CAGE };

--- a/RoiPainter4D/RoiPainter4D/FormSegStrokeFfd.h
+++ b/RoiPainter4D/RoiPainter4D/FormSegStrokeFfd.h
@@ -95,401 +95,401 @@ namespace RoiPainter4D {
     /// </summary>
     void InitializeComponent(void)
     {
-      this->m_btn_loadmeshandcage = (gcnew System::Windows::Forms::Button());
-      this->m_btn_savemeshandcage = (gcnew System::Windows::Forms::Button());
-      this->m_btn_loadstate = (gcnew System::Windows::Forms::Button());
-      this->m_btn_savestate = (gcnew System::Windows::Forms::Button());
-      this->m_textbox_alpha = (gcnew System::Windows::Forms::TextBox());
-      this->m_textbox_beta = (gcnew System::Windows::Forms::TextBox());
-      this->m_textbox_gamma = (gcnew System::Windows::Forms::TextBox());
-      this->m_btn_deform = (gcnew System::Windows::Forms::Button());
-      this->m_btn_flipnormal = (gcnew System::Windows::Forms::Button());
-      this->label1 = (gcnew System::Windows::Forms::Label());
-      this->label2 = (gcnew System::Windows::Forms::Label());
-      this->label3 = (gcnew System::Windows::Forms::Label());
-      this->m_btn_undo = (gcnew System::Windows::Forms::Button());
-      this->m_btn_copyfromprevframe = (gcnew System::Windows::Forms::Button());
-      this->m_radiobtn_movement = (gcnew System::Windows::Forms::RadioButton());
-      this->m_radiobtn_rotation = (gcnew System::Windows::Forms::RadioButton());
-      this->m_radiobtn_scaling = (gcnew System::Windows::Forms::RadioButton());
-      this->m_btn_sharestroke = (gcnew System::Windows::Forms::Button());
-      this->m_radiobtn_stroke = (gcnew System::Windows::Forms::RadioButton());
-      this->m_radiobtn_cage = (gcnew System::Windows::Forms::RadioButton());
-      this->groupBox1 = (gcnew System::Windows::Forms::GroupBox());
-      this->groupBox2 = (gcnew System::Windows::Forms::GroupBox());
-      this->m_numbox_cpsize = (gcnew System::Windows::Forms::NumericUpDown());
-      this->label4 = (gcnew System::Windows::Forms::Label());
-      this->m_checkbox_showonlyselectedstroke = (gcnew System::Windows::Forms::CheckBox());
-      this->m_btn_copycagetoallframes = (gcnew System::Windows::Forms::Button());
-      this->groupBox3 = (gcnew System::Windows::Forms::GroupBox());
-      this->label6 = (gcnew System::Windows::Forms::Label());
-      this->label5 = (gcnew System::Windows::Forms::Label());
-      this->m_btn_finish_segmentation = (gcnew System::Windows::Forms::Button());
-      this->groupBox1->SuspendLayout();
-      this->groupBox2->SuspendLayout();
-      (cli::safe_cast<System::ComponentModel::ISupportInitialize^>(this->m_numbox_cpsize))->BeginInit();
-      this->groupBox3->SuspendLayout();
-      this->SuspendLayout();
-      // 
-      // m_btn_loadmeshandcage
-      // 
-      this->m_btn_loadmeshandcage->Location = System::Drawing::Point(12, 12);
-      this->m_btn_loadmeshandcage->Name = L"m_btn_loadmeshandcage";
-      this->m_btn_loadmeshandcage->Size = System::Drawing::Size(138, 23);
-      this->m_btn_loadmeshandcage->TabIndex = 0;
-      this->m_btn_loadmeshandcage->Text = L"Import mesh＆cage";
-      this->m_btn_loadmeshandcage->UseVisualStyleBackColor = true;
-      this->m_btn_loadmeshandcage->Click += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_btn_loadmeshandcage_Click);
-      // 
-      // m_btn_savemeshandcage
-      // 
-      this->m_btn_savemeshandcage->Location = System::Drawing::Point(153, 12);
-      this->m_btn_savemeshandcage->Margin = System::Windows::Forms::Padding(2);
-      this->m_btn_savemeshandcage->Name = L"m_btn_savemeshandcage";
-      this->m_btn_savemeshandcage->Size = System::Drawing::Size(120, 23);
-      this->m_btn_savemeshandcage->TabIndex = 1;
-      this->m_btn_savemeshandcage->Text = L"Export mesh＆cage";
-      this->m_btn_savemeshandcage->UseVisualStyleBackColor = true;
-      this->m_btn_savemeshandcage->Click += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_btn_savemeshandcage_Click);
-      // 
-      // m_btn_loadstate
-      // 
-      this->m_btn_loadstate->Location = System::Drawing::Point(14, 446);
-      this->m_btn_loadstate->Margin = System::Windows::Forms::Padding(2);
-      this->m_btn_loadstate->Name = L"m_btn_loadstate";
-      this->m_btn_loadstate->Size = System::Drawing::Size(142, 23);
-      this->m_btn_loadstate->TabIndex = 2;
-      this->m_btn_loadstate->Text = L"Load cage and curves";
-      this->m_btn_loadstate->UseVisualStyleBackColor = true;
-      this->m_btn_loadstate->Click += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_btn_loadstate_Click);
-      // 
-      // m_btn_savestate
-      // 
-      this->m_btn_savestate->Location = System::Drawing::Point(14, 419);
-      this->m_btn_savestate->Margin = System::Windows::Forms::Padding(2);
-      this->m_btn_savestate->Name = L"m_btn_savestate";
-      this->m_btn_savestate->Size = System::Drawing::Size(142, 23);
-      this->m_btn_savestate->TabIndex = 3;
-      this->m_btn_savestate->Text = L"Save Cage and curves";
-      this->m_btn_savestate->UseVisualStyleBackColor = true;
-      this->m_btn_savestate->Click += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_btn_savestate_Click);
-      // 
-      // m_textbox_alpha
-      // 
-      this->m_textbox_alpha->Location = System::Drawing::Point(199, 18);
-      this->m_textbox_alpha->Name = L"m_textbox_alpha";
-      this->m_textbox_alpha->Size = System::Drawing::Size(38, 19);
-      this->m_textbox_alpha->TabIndex = 4;
-      this->m_textbox_alpha->Text = L"1.0";
-      // 
-      // m_textbox_beta
-      // 
-      this->m_textbox_beta->Location = System::Drawing::Point(199, 43);
-      this->m_textbox_beta->Name = L"m_textbox_beta";
-      this->m_textbox_beta->Size = System::Drawing::Size(38, 19);
-      this->m_textbox_beta->TabIndex = 5;
-      this->m_textbox_beta->Text = L"1.0";
-      // 
-      // m_textbox_gamma
-      // 
-      this->m_textbox_gamma->Location = System::Drawing::Point(199, 68);
-      this->m_textbox_gamma->Name = L"m_textbox_gamma";
-      this->m_textbox_gamma->Size = System::Drawing::Size(38, 19);
-      this->m_textbox_gamma->TabIndex = 6;
-      this->m_textbox_gamma->Text = L"5.0";
-      // 
-      // m_btn_deform
-      // 
-      this->m_btn_deform->Location = System::Drawing::Point(6, 17);
-      this->m_btn_deform->Margin = System::Windows::Forms::Padding(2);
-      this->m_btn_deform->Name = L"m_btn_deform";
-      this->m_btn_deform->Size = System::Drawing::Size(157, 32);
-      this->m_btn_deform->TabIndex = 7;
-      this->m_btn_deform->Text = L"Deform (変形を計算)";
-      this->m_btn_deform->UseVisualStyleBackColor = true;
-      this->m_btn_deform->Click += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_btn_deform_Click);
-      // 
-      // m_btn_flipnormal
-      // 
-      this->m_btn_flipnormal->Location = System::Drawing::Point(6, 117);
-      this->m_btn_flipnormal->Name = L"m_btn_flipnormal";
-      this->m_btn_flipnormal->Size = System::Drawing::Size(157, 23);
-      this->m_btn_flipnormal->TabIndex = 30;
-      this->m_btn_flipnormal->Text = L"Flip normals";
-      this->m_btn_flipnormal->UseVisualStyleBackColor = true;
-      this->m_btn_flipnormal->Click += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_btn_flipnormal_Click);
-      // 
-      // label1
-      // 
-      this->label1->AutoSize = true;
-      this->label1->Location = System::Drawing::Point(179, 21);
-      this->label1->Name = L"label1";
-      this->label1->Size = System::Drawing::Size(19, 12);
-      this->label1->TabIndex = 8;
-      this->label1->Text = L"α:";
-      // 
-      // label2
-      // 
-      this->label2->AutoSize = true;
-      this->label2->Location = System::Drawing::Point(177, 46);
-      this->label2->Name = L"label2";
-      this->label2->Size = System::Drawing::Size(19, 12);
-      this->label2->TabIndex = 9;
-      this->label2->Text = L"β:";
-      // 
-      // label3
-      // 
-      this->label3->AutoSize = true;
-      this->label3->Location = System::Drawing::Point(177, 71);
-      this->label3->Name = L"label3";
-      this->label3->Size = System::Drawing::Size(19, 12);
-      this->label3->TabIndex = 10;
-      this->label3->Text = L"γ:";
-      // 
-      // m_btn_undo
-      // 
-      this->m_btn_undo->Location = System::Drawing::Point(160, 419);
-      this->m_btn_undo->Margin = System::Windows::Forms::Padding(2);
-      this->m_btn_undo->Name = L"m_btn_undo";
-      this->m_btn_undo->Size = System::Drawing::Size(59, 23);
-      this->m_btn_undo->TabIndex = 11;
-      this->m_btn_undo->Text = L"UNDO";
-      this->m_btn_undo->UseVisualStyleBackColor = true;
-      this->m_btn_undo->Click += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_btn_undo_Click);
-      // 
-      // m_btn_copyfromprevframe
-      // 
-      this->m_btn_copyfromprevframe->Location = System::Drawing::Point(6, 86);
-      this->m_btn_copyfromprevframe->Margin = System::Windows::Forms::Padding(2);
-      this->m_btn_copyfromprevframe->Name = L"m_btn_copyfromprevframe";
-      this->m_btn_copyfromprevframe->Size = System::Drawing::Size(157, 26);
-      this->m_btn_copyfromprevframe->TabIndex = 13;
-      this->m_btn_copyfromprevframe->Text = L"Copy curves from pre_frame";
-      this->m_btn_copyfromprevframe->UseVisualStyleBackColor = true;
-      this->m_btn_copyfromprevframe->Click += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_btn_copyfromprevframe_Click);
-      // 
-      // m_radiobtn_movement
-      // 
-      this->m_radiobtn_movement->AutoSize = true;
-      this->m_radiobtn_movement->Checked = true;
-      this->m_radiobtn_movement->Location = System::Drawing::Point(6, 18);
-      this->m_radiobtn_movement->Name = L"m_radiobtn_movement";
-      this->m_radiobtn_movement->Size = System::Drawing::Size(80, 16);
-      this->m_radiobtn_movement->TabIndex = 14;
-      this->m_radiobtn_movement->TabStop = true;
-      this->m_radiobtn_movement->Text = L"Translation";
-      this->m_radiobtn_movement->UseVisualStyleBackColor = true;
-      this->m_radiobtn_movement->CheckedChanged += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_radiobtn_movement_CheckedChanged);
-      // 
-      // m_radiobtn_rotation
-      // 
-      this->m_radiobtn_rotation->AutoSize = true;
-      this->m_radiobtn_rotation->Location = System::Drawing::Point(6, 40);
-      this->m_radiobtn_rotation->Name = L"m_radiobtn_rotation";
-      this->m_radiobtn_rotation->Size = System::Drawing::Size(66, 16);
-      this->m_radiobtn_rotation->TabIndex = 15;
-      this->m_radiobtn_rotation->Text = L"Rotation";
-      this->m_radiobtn_rotation->UseVisualStyleBackColor = true;
-      this->m_radiobtn_rotation->CheckedChanged += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_radiobtn_rotation_CheckedChanged);
-      // 
-      // m_radiobtn_scaling
-      // 
-      this->m_radiobtn_scaling->AutoSize = true;
-      this->m_radiobtn_scaling->Location = System::Drawing::Point(6, 62);
-      this->m_radiobtn_scaling->Name = L"m_radiobtn_scaling";
-      this->m_radiobtn_scaling->Size = System::Drawing::Size(60, 16);
-      this->m_radiobtn_scaling->TabIndex = 16;
-      this->m_radiobtn_scaling->Text = L"Scaling";
-      this->m_radiobtn_scaling->UseVisualStyleBackColor = true;
-      this->m_radiobtn_scaling->CheckedChanged += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_radiobtn_scaling_CheckedChanged);
-      // 
-      // m_btn_sharestroke
-      // 
-      this->m_btn_sharestroke->Font = (gcnew System::Drawing::Font(L"MS UI Gothic", 9));
-      this->m_btn_sharestroke->Location = System::Drawing::Point(6, 54);
-      this->m_btn_sharestroke->Name = L"m_btn_sharestroke";
-      this->m_btn_sharestroke->Size = System::Drawing::Size(157, 27);
-      this->m_btn_sharestroke->TabIndex = 18;
-      this->m_btn_sharestroke->Text = L"Set as all frame curve\r\n";
-      this->m_btn_sharestroke->UseVisualStyleBackColor = true;
-      this->m_btn_sharestroke->Click += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_btn_sharestroke_Click);
-      // 
-      // m_radiobtn_stroke
-      // 
-      this->m_radiobtn_stroke->AutoSize = true;
-      this->m_radiobtn_stroke->Checked = true;
-      this->m_radiobtn_stroke->Location = System::Drawing::Point(6, 18);
-      this->m_radiobtn_stroke->Name = L"m_radiobtn_stroke";
-      this->m_radiobtn_stroke->Size = System::Drawing::Size(53, 16);
-      this->m_radiobtn_stroke->TabIndex = 20;
-      this->m_radiobtn_stroke->TabStop = true;
-      this->m_radiobtn_stroke->Text = L"Curve";
-      this->m_radiobtn_stroke->UseVisualStyleBackColor = true;
-      this->m_radiobtn_stroke->CheckedChanged += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_radiobtn_stroke_CheckedChanged);
-      // 
-      // m_radiobtn_cage
-      // 
-      this->m_radiobtn_cage->AutoSize = true;
-      this->m_radiobtn_cage->Location = System::Drawing::Point(67, 18);
-      this->m_radiobtn_cage->Name = L"m_radiobtn_cage";
-      this->m_radiobtn_cage->Size = System::Drawing::Size(49, 16);
-      this->m_radiobtn_cage->TabIndex = 21;
-      this->m_radiobtn_cage->Text = L"Cage";
-      this->m_radiobtn_cage->UseVisualStyleBackColor = true;
-      this->m_radiobtn_cage->CheckedChanged += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_radiobtn_cage_CheckedChanged);
-      // 
-      // groupBox1
-      // 
-      this->groupBox1->Controls->Add(this->m_radiobtn_movement);
-      this->groupBox1->Controls->Add(this->m_radiobtn_rotation);
-      this->groupBox1->Controls->Add(this->m_radiobtn_scaling);
-      this->groupBox1->Location = System::Drawing::Point(147, 71);
-      this->groupBox1->Name = L"groupBox1";
-      this->groupBox1->Size = System::Drawing::Size(117, 85);
-      this->groupBox1->TabIndex = 22;
-      this->groupBox1->TabStop = false;
-      this->groupBox1->Text = L"Transform mode";
-      // 
-      // groupBox2
-      // 
-      this->groupBox2->Controls->Add(this->m_radiobtn_cage);
-      this->groupBox2->Controls->Add(this->m_radiobtn_stroke);
-      this->groupBox2->Location = System::Drawing::Point(14, 71);
-      this->groupBox2->Name = L"groupBox2";
-      this->groupBox2->Size = System::Drawing::Size(127, 45);
-      this->groupBox2->TabIndex = 23;
-      this->groupBox2->TabStop = false;
-      this->groupBox2->Text = L"Deform mode";
-      // 
-      // m_numbox_cpsize
-      // 
-      this->m_numbox_cpsize->Font = (gcnew System::Drawing::Font(L"MS UI Gothic", 11.5F));
-      this->m_numbox_cpsize->Location = System::Drawing::Point(73, 126);
-      this->m_numbox_cpsize->Minimum = System::Decimal(gcnew cli::array< System::Int32 >(4) { 1, 0, 0, 0 });
-      this->m_numbox_cpsize->Name = L"m_numbox_cpsize";
-      this->m_numbox_cpsize->Size = System::Drawing::Size(57, 23);
-      this->m_numbox_cpsize->TabIndex = 24;
-      this->m_numbox_cpsize->TextAlign = System::Windows::Forms::HorizontalAlignment::Right;
-      this->m_numbox_cpsize->Value = System::Decimal(gcnew cli::array< System::Int32 >(4) { 10, 0, 0, 0 });
-      this->m_numbox_cpsize->ValueChanged += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_numbox_cpsize_ValueChanged);
-      // 
-      // label4
-      // 
-      this->label4->AutoSize = true;
-      this->label4->Location = System::Drawing::Point(21, 131);
-      this->label4->Name = L"label4";
-      this->label4->Size = System::Drawing::Size(46, 12);
-      this->label4->TabIndex = 25;
-      this->label4->Text = L"CP size:";
-      // 
-      // m_checkbox_showonlyselectedstroke
-      // 
-      this->m_checkbox_showonlyselectedstroke->AutoSize = true;
-      this->m_checkbox_showonlyselectedstroke->Font = (gcnew System::Drawing::Font(L"MS UI Gothic", 8));
-      this->m_checkbox_showonlyselectedstroke->Location = System::Drawing::Point(9, 146);
-      this->m_checkbox_showonlyselectedstroke->Name = L"m_checkbox_showonlyselectedstroke";
-      this->m_checkbox_showonlyselectedstroke->Size = System::Drawing::Size(148, 15);
-      this->m_checkbox_showonlyselectedstroke->TabIndex = 26;
-      this->m_checkbox_showonlyselectedstroke->Text = L"Show only selected stroke";
-      this->m_checkbox_showonlyselectedstroke->UseVisualStyleBackColor = true;
-      this->m_checkbox_showonlyselectedstroke->CheckedChanged += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_checkbox_showonlyselectedstroke_CheckedChanged);
-      // 
-      // m_btn_copycagetoallframes
-      // 
-      this->m_btn_copycagetoallframes->Location = System::Drawing::Point(14, 40);
-      this->m_btn_copycagetoallframes->Name = L"m_btn_copycagetoallframes";
-      this->m_btn_copycagetoallframes->Size = System::Drawing::Size(136, 23);
-      this->m_btn_copycagetoallframes->TabIndex = 27;
-      this->m_btn_copycagetoallframes->Text = L"Copy cage to all frames";
-      this->m_btn_copycagetoallframes->UseVisualStyleBackColor = true;
-      this->m_btn_copycagetoallframes->Click += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_btn_copycagetoallframes_Click);
-      // 
-      // groupBox3
-      // 
-      this->groupBox3->Controls->Add(this->label6);
-      this->groupBox3->Controls->Add(this->label5);
-      this->groupBox3->Controls->Add(this->m_btn_deform);
-      this->groupBox3->Controls->Add(this->m_btn_copyfromprevframe);
-      this->groupBox3->Controls->Add(this->m_checkbox_showonlyselectedstroke);
-      this->groupBox3->Controls->Add(this->m_btn_sharestroke);
-      this->groupBox3->Controls->Add(this->m_btn_flipnormal);
-      this->groupBox3->Controls->Add(this->m_textbox_gamma);
-      this->groupBox3->Controls->Add(this->m_textbox_alpha);
-      this->groupBox3->Controls->Add(this->m_textbox_beta);
-      this->groupBox3->Controls->Add(this->label3);
-      this->groupBox3->Controls->Add(this->label2);
-      this->groupBox3->Controls->Add(this->label1);
-      this->groupBox3->Location = System::Drawing::Point(14, 162);
-      this->groupBox3->Name = L"groupBox3";
-      this->groupBox3->Size = System::Drawing::Size(252, 252);
-      this->groupBox3->TabIndex = 28;
-      this->groupBox3->TabStop = false;
-      this->groupBox3->Text = L"Stroke ＆ Deformation";
-      // 
-      // label6
-      // 
-      this->label6->AutoSize = true;
-      this->label6->Font = (gcnew System::Drawing::Font(L"ＭＳ ゴシック", 9, System::Drawing::FontStyle::Regular, System::Drawing::GraphicsUnit::Point,
-        static_cast<System::Byte>(128)));
-      this->label6->Location = System::Drawing::Point(7, 213);
-      this->label6->Name = L"label6";
-      this->label6->Size = System::Drawing::Size(179, 36);
-      this->label6->TabIndex = 29;
-      this->label6->Text = L"Shift + 左 click - 制御点追加\r\nShift + 左 drag - 制御点移動 \r\nShift + 右 down - 制御点削除\r\n";
-      // 
-      // label5
-      // 
-      this->label5->AutoSize = true;
-      this->label5->Font = (gcnew System::Drawing::Font(L"ＭＳ ゴシック", 9, System::Drawing::FontStyle::Regular, System::Drawing::GraphicsUnit::Point,
-        static_cast<System::Byte>(128)));
-      this->label5->Location = System::Drawing::Point(7, 168);
-      this->label5->Name = L"label5";
-      this->label5->Size = System::Drawing::Size(137, 36);
-      this->label5->TabIndex = 29;
-      this->label5->Text = L"　 赤: 選択中のcurve\r\n　 黄: 未選択のcurve\r\n緑/青: all frame curve";
-      // 
-      // m_btn_finish_segmentation
-      // 
-      this->m_btn_finish_segmentation->Font = (gcnew System::Drawing::Font(L"MS UI Gothic", 11.25F, System::Drawing::FontStyle::Bold, System::Drawing::GraphicsUnit::Point,
-        static_cast<System::Byte>(128)));
-      this->m_btn_finish_segmentation->Location = System::Drawing::Point(14, 473);
-      this->m_btn_finish_segmentation->Margin = System::Windows::Forms::Padding(2);
-      this->m_btn_finish_segmentation->Name = L"m_btn_finish_segmentation";
-      this->m_btn_finish_segmentation->Size = System::Drawing::Size(191, 32);
-      this->m_btn_finish_segmentation->TabIndex = 29;
-      this->m_btn_finish_segmentation->Text = L"Finish And Store ROI";
-      this->m_btn_finish_segmentation->UseVisualStyleBackColor = true;
-      this->m_btn_finish_segmentation->Click += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_btn_finish_segmentation_Click);
-      // 
-      // FormSegStrokeFfd
-      // 
-      this->AutoScaleDimensions = System::Drawing::SizeF(6, 12);
-      this->AutoScaleMode = System::Windows::Forms::AutoScaleMode::Font;
-      this->ClientSize = System::Drawing::Size(278, 507);
-      this->Controls->Add(this->m_btn_finish_segmentation);
-      this->Controls->Add(this->groupBox3);
-      this->Controls->Add(this->m_btn_copycagetoallframes);
-      this->Controls->Add(this->label4);
-      this->Controls->Add(this->m_numbox_cpsize);
-      this->Controls->Add(this->groupBox2);
-      this->Controls->Add(this->m_btn_savestate);
-      this->Controls->Add(this->groupBox1);
-      this->Controls->Add(this->m_btn_loadstate);
-      this->Controls->Add(this->m_btn_undo);
-      this->Controls->Add(this->m_btn_savemeshandcage);
-      this->Controls->Add(this->m_btn_loadmeshandcage);
-      this->Name = L"FormSegStrokeFfd";
-      this->Text = L"FormSegStrokeFfd";
-      this->Load += gcnew System::EventHandler(this, &FormSegStrokeFfd::FormSegStrokeFfd_Load);
-      this->groupBox1->ResumeLayout(false);
-      this->groupBox1->PerformLayout();
-      this->groupBox2->ResumeLayout(false);
-      this->groupBox2->PerformLayout();
-      (cli::safe_cast<System::ComponentModel::ISupportInitialize^>(this->m_numbox_cpsize))->EndInit();
-      this->groupBox3->ResumeLayout(false);
-      this->groupBox3->PerformLayout();
-      this->ResumeLayout(false);
-      this->PerformLayout();
+        this->m_btn_loadmeshandcage = (gcnew System::Windows::Forms::Button());
+        this->m_btn_savemeshandcage = (gcnew System::Windows::Forms::Button());
+        this->m_btn_loadstate = (gcnew System::Windows::Forms::Button());
+        this->m_btn_savestate = (gcnew System::Windows::Forms::Button());
+        this->m_textbox_alpha = (gcnew System::Windows::Forms::TextBox());
+        this->m_textbox_beta = (gcnew System::Windows::Forms::TextBox());
+        this->m_textbox_gamma = (gcnew System::Windows::Forms::TextBox());
+        this->m_btn_deform = (gcnew System::Windows::Forms::Button());
+        this->m_btn_flipnormal = (gcnew System::Windows::Forms::Button());
+        this->label1 = (gcnew System::Windows::Forms::Label());
+        this->label2 = (gcnew System::Windows::Forms::Label());
+        this->label3 = (gcnew System::Windows::Forms::Label());
+        this->m_btn_undo = (gcnew System::Windows::Forms::Button());
+        this->m_btn_copyfromprevframe = (gcnew System::Windows::Forms::Button());
+        this->m_radiobtn_movement = (gcnew System::Windows::Forms::RadioButton());
+        this->m_radiobtn_rotation = (gcnew System::Windows::Forms::RadioButton());
+        this->m_radiobtn_scaling = (gcnew System::Windows::Forms::RadioButton());
+        this->m_btn_sharestroke = (gcnew System::Windows::Forms::Button());
+        this->m_radiobtn_stroke = (gcnew System::Windows::Forms::RadioButton());
+        this->m_radiobtn_cage = (gcnew System::Windows::Forms::RadioButton());
+        this->groupBox1 = (gcnew System::Windows::Forms::GroupBox());
+        this->groupBox2 = (gcnew System::Windows::Forms::GroupBox());
+        this->m_numbox_cpsize = (gcnew System::Windows::Forms::NumericUpDown());
+        this->label4 = (gcnew System::Windows::Forms::Label());
+        this->m_checkbox_showonlyselectedstroke = (gcnew System::Windows::Forms::CheckBox());
+        this->m_btn_copycagetoallframes = (gcnew System::Windows::Forms::Button());
+        this->groupBox3 = (gcnew System::Windows::Forms::GroupBox());
+        this->label6 = (gcnew System::Windows::Forms::Label());
+        this->label5 = (gcnew System::Windows::Forms::Label());
+        this->m_btn_finish_segmentation = (gcnew System::Windows::Forms::Button());
+        this->groupBox1->SuspendLayout();
+        this->groupBox2->SuspendLayout();
+        (cli::safe_cast<System::ComponentModel::ISupportInitialize^>(this->m_numbox_cpsize))->BeginInit();
+        this->groupBox3->SuspendLayout();
+        this->SuspendLayout();
+        // 
+        // m_btn_loadmeshandcage
+        // 
+        this->m_btn_loadmeshandcage->Location = System::Drawing::Point(12, 12);
+        this->m_btn_loadmeshandcage->Name = L"m_btn_loadmeshandcage";
+        this->m_btn_loadmeshandcage->Size = System::Drawing::Size(138, 23);
+        this->m_btn_loadmeshandcage->TabIndex = 0;
+        this->m_btn_loadmeshandcage->Text = L"Import mesh＆cage";
+        this->m_btn_loadmeshandcage->UseVisualStyleBackColor = true;
+        this->m_btn_loadmeshandcage->Click += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_btn_loadmeshandcage_Click);
+        // 
+        // m_btn_savemeshandcage
+        // 
+        this->m_btn_savemeshandcage->Location = System::Drawing::Point(153, 12);
+        this->m_btn_savemeshandcage->Margin = System::Windows::Forms::Padding(2);
+        this->m_btn_savemeshandcage->Name = L"m_btn_savemeshandcage";
+        this->m_btn_savemeshandcage->Size = System::Drawing::Size(120, 23);
+        this->m_btn_savemeshandcage->TabIndex = 1;
+        this->m_btn_savemeshandcage->Text = L"Export mesh＆cage";
+        this->m_btn_savemeshandcage->UseVisualStyleBackColor = true;
+        this->m_btn_savemeshandcage->Click += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_btn_savemeshandcage_Click);
+        // 
+        // m_btn_loadstate
+        // 
+        this->m_btn_loadstate->Location = System::Drawing::Point(14, 446);
+        this->m_btn_loadstate->Margin = System::Windows::Forms::Padding(2);
+        this->m_btn_loadstate->Name = L"m_btn_loadstate";
+        this->m_btn_loadstate->Size = System::Drawing::Size(142, 23);
+        this->m_btn_loadstate->TabIndex = 2;
+        this->m_btn_loadstate->Text = L"Load cage and curves";
+        this->m_btn_loadstate->UseVisualStyleBackColor = true;
+        this->m_btn_loadstate->Click += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_btn_loadstate_Click);
+        // 
+        // m_btn_savestate
+        // 
+        this->m_btn_savestate->Location = System::Drawing::Point(14, 419);
+        this->m_btn_savestate->Margin = System::Windows::Forms::Padding(2);
+        this->m_btn_savestate->Name = L"m_btn_savestate";
+        this->m_btn_savestate->Size = System::Drawing::Size(142, 23);
+        this->m_btn_savestate->TabIndex = 3;
+        this->m_btn_savestate->Text = L"Save Cage and curves";
+        this->m_btn_savestate->UseVisualStyleBackColor = true;
+        this->m_btn_savestate->Click += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_btn_savestate_Click);
+        // 
+        // m_textbox_alpha
+        // 
+        this->m_textbox_alpha->Location = System::Drawing::Point(199, 18);
+        this->m_textbox_alpha->Name = L"m_textbox_alpha";
+        this->m_textbox_alpha->Size = System::Drawing::Size(38, 19);
+        this->m_textbox_alpha->TabIndex = 4;
+        this->m_textbox_alpha->Text = L"1.0";
+        // 
+        // m_textbox_beta
+        // 
+        this->m_textbox_beta->Location = System::Drawing::Point(199, 43);
+        this->m_textbox_beta->Name = L"m_textbox_beta";
+        this->m_textbox_beta->Size = System::Drawing::Size(38, 19);
+        this->m_textbox_beta->TabIndex = 5;
+        this->m_textbox_beta->Text = L"1.0";
+        // 
+        // m_textbox_gamma
+        // 
+        this->m_textbox_gamma->Location = System::Drawing::Point(199, 68);
+        this->m_textbox_gamma->Name = L"m_textbox_gamma";
+        this->m_textbox_gamma->Size = System::Drawing::Size(38, 19);
+        this->m_textbox_gamma->TabIndex = 6;
+        this->m_textbox_gamma->Text = L"5.0";
+        // 
+        // m_btn_deform
+        // 
+        this->m_btn_deform->Location = System::Drawing::Point(6, 17);
+        this->m_btn_deform->Margin = System::Windows::Forms::Padding(2);
+        this->m_btn_deform->Name = L"m_btn_deform";
+        this->m_btn_deform->Size = System::Drawing::Size(168, 32);
+        this->m_btn_deform->TabIndex = 7;
+        this->m_btn_deform->Text = L"Deform (変形を計算)";
+        this->m_btn_deform->UseVisualStyleBackColor = true;
+        this->m_btn_deform->Click += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_btn_deform_Click);
+        // 
+        // m_btn_flipnormal
+        // 
+        this->m_btn_flipnormal->Location = System::Drawing::Point(6, 117);
+        this->m_btn_flipnormal->Name = L"m_btn_flipnormal";
+        this->m_btn_flipnormal->Size = System::Drawing::Size(168, 23);
+        this->m_btn_flipnormal->TabIndex = 30;
+        this->m_btn_flipnormal->Text = L"Flip normals";
+        this->m_btn_flipnormal->UseVisualStyleBackColor = true;
+        this->m_btn_flipnormal->Click += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_btn_flipnormal_Click);
+        // 
+        // label1
+        // 
+        this->label1->AutoSize = true;
+        this->label1->Location = System::Drawing::Point(179, 21);
+        this->label1->Name = L"label1";
+        this->label1->Size = System::Drawing::Size(19, 12);
+        this->label1->TabIndex = 8;
+        this->label1->Text = L"α:";
+        // 
+        // label2
+        // 
+        this->label2->AutoSize = true;
+        this->label2->Location = System::Drawing::Point(177, 46);
+        this->label2->Name = L"label2";
+        this->label2->Size = System::Drawing::Size(19, 12);
+        this->label2->TabIndex = 9;
+        this->label2->Text = L"β:";
+        // 
+        // label3
+        // 
+        this->label3->AutoSize = true;
+        this->label3->Location = System::Drawing::Point(177, 71);
+        this->label3->Name = L"label3";
+        this->label3->Size = System::Drawing::Size(19, 12);
+        this->label3->TabIndex = 10;
+        this->label3->Text = L"γ:";
+        // 
+        // m_btn_undo
+        // 
+        this->m_btn_undo->Location = System::Drawing::Point(160, 419);
+        this->m_btn_undo->Margin = System::Windows::Forms::Padding(2);
+        this->m_btn_undo->Name = L"m_btn_undo";
+        this->m_btn_undo->Size = System::Drawing::Size(59, 23);
+        this->m_btn_undo->TabIndex = 11;
+        this->m_btn_undo->Text = L"UNDO";
+        this->m_btn_undo->UseVisualStyleBackColor = true;
+        this->m_btn_undo->Click += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_btn_undo_Click);
+        // 
+        // m_btn_copyfromprevframe
+        // 
+        this->m_btn_copyfromprevframe->Location = System::Drawing::Point(6, 86);
+        this->m_btn_copyfromprevframe->Margin = System::Windows::Forms::Padding(2);
+        this->m_btn_copyfromprevframe->Name = L"m_btn_copyfromprevframe";
+        this->m_btn_copyfromprevframe->Size = System::Drawing::Size(168, 26);
+        this->m_btn_copyfromprevframe->TabIndex = 13;
+        this->m_btn_copyfromprevframe->Text = L"Copy curves from pre_frame";
+        this->m_btn_copyfromprevframe->UseVisualStyleBackColor = true;
+        this->m_btn_copyfromprevframe->Click += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_btn_copyfromprevframe_Click);
+        // 
+        // m_radiobtn_movement
+        // 
+        this->m_radiobtn_movement->AutoSize = true;
+        this->m_radiobtn_movement->Checked = true;
+        this->m_radiobtn_movement->Location = System::Drawing::Point(6, 18);
+        this->m_radiobtn_movement->Name = L"m_radiobtn_movement";
+        this->m_radiobtn_movement->Size = System::Drawing::Size(80, 16);
+        this->m_radiobtn_movement->TabIndex = 14;
+        this->m_radiobtn_movement->TabStop = true;
+        this->m_radiobtn_movement->Text = L"Translation";
+        this->m_radiobtn_movement->UseVisualStyleBackColor = true;
+        this->m_radiobtn_movement->CheckedChanged += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_radiobtn_movement_CheckedChanged);
+        // 
+        // m_radiobtn_rotation
+        // 
+        this->m_radiobtn_rotation->AutoSize = true;
+        this->m_radiobtn_rotation->Location = System::Drawing::Point(6, 40);
+        this->m_radiobtn_rotation->Name = L"m_radiobtn_rotation";
+        this->m_radiobtn_rotation->Size = System::Drawing::Size(66, 16);
+        this->m_radiobtn_rotation->TabIndex = 15;
+        this->m_radiobtn_rotation->Text = L"Rotation";
+        this->m_radiobtn_rotation->UseVisualStyleBackColor = true;
+        this->m_radiobtn_rotation->CheckedChanged += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_radiobtn_rotation_CheckedChanged);
+        // 
+        // m_radiobtn_scaling
+        // 
+        this->m_radiobtn_scaling->AutoSize = true;
+        this->m_radiobtn_scaling->Location = System::Drawing::Point(6, 62);
+        this->m_radiobtn_scaling->Name = L"m_radiobtn_scaling";
+        this->m_radiobtn_scaling->Size = System::Drawing::Size(60, 16);
+        this->m_radiobtn_scaling->TabIndex = 16;
+        this->m_radiobtn_scaling->Text = L"Scaling";
+        this->m_radiobtn_scaling->UseVisualStyleBackColor = true;
+        this->m_radiobtn_scaling->CheckedChanged += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_radiobtn_scaling_CheckedChanged);
+        // 
+        // m_btn_sharestroke
+        // 
+        this->m_btn_sharestroke->Font = (gcnew System::Drawing::Font(L"MS UI Gothic", 9));
+        this->m_btn_sharestroke->Location = System::Drawing::Point(6, 54);
+        this->m_btn_sharestroke->Name = L"m_btn_sharestroke";
+        this->m_btn_sharestroke->Size = System::Drawing::Size(168, 27);
+        this->m_btn_sharestroke->TabIndex = 18;
+        this->m_btn_sharestroke->Text = L"Set as all frame curve\r\n";
+        this->m_btn_sharestroke->UseVisualStyleBackColor = true;
+        this->m_btn_sharestroke->Click += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_btn_sharestroke_Click);
+        // 
+        // m_radiobtn_stroke
+        // 
+        this->m_radiobtn_stroke->AutoSize = true;
+        this->m_radiobtn_stroke->Checked = true;
+        this->m_radiobtn_stroke->Location = System::Drawing::Point(6, 18);
+        this->m_radiobtn_stroke->Name = L"m_radiobtn_stroke";
+        this->m_radiobtn_stroke->Size = System::Drawing::Size(53, 16);
+        this->m_radiobtn_stroke->TabIndex = 20;
+        this->m_radiobtn_stroke->TabStop = true;
+        this->m_radiobtn_stroke->Text = L"Curve";
+        this->m_radiobtn_stroke->UseVisualStyleBackColor = true;
+        this->m_radiobtn_stroke->CheckedChanged += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_radiobtn_stroke_CheckedChanged);
+        // 
+        // m_radiobtn_cage
+        // 
+        this->m_radiobtn_cage->AutoSize = true;
+        this->m_radiobtn_cage->Location = System::Drawing::Point(67, 18);
+        this->m_radiobtn_cage->Name = L"m_radiobtn_cage";
+        this->m_radiobtn_cage->Size = System::Drawing::Size(49, 16);
+        this->m_radiobtn_cage->TabIndex = 21;
+        this->m_radiobtn_cage->Text = L"Cage";
+        this->m_radiobtn_cage->UseVisualStyleBackColor = true;
+        this->m_radiobtn_cage->CheckedChanged += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_radiobtn_cage_CheckedChanged);
+        // 
+        // groupBox1
+        // 
+        this->groupBox1->Controls->Add(this->m_radiobtn_movement);
+        this->groupBox1->Controls->Add(this->m_radiobtn_rotation);
+        this->groupBox1->Controls->Add(this->m_radiobtn_scaling);
+        this->groupBox1->Location = System::Drawing::Point(147, 71);
+        this->groupBox1->Name = L"groupBox1";
+        this->groupBox1->Size = System::Drawing::Size(117, 85);
+        this->groupBox1->TabIndex = 22;
+        this->groupBox1->TabStop = false;
+        this->groupBox1->Text = L"Transform mode";
+        // 
+        // groupBox2
+        // 
+        this->groupBox2->Controls->Add(this->m_radiobtn_cage);
+        this->groupBox2->Controls->Add(this->m_radiobtn_stroke);
+        this->groupBox2->Location = System::Drawing::Point(14, 71);
+        this->groupBox2->Name = L"groupBox2";
+        this->groupBox2->Size = System::Drawing::Size(127, 45);
+        this->groupBox2->TabIndex = 23;
+        this->groupBox2->TabStop = false;
+        this->groupBox2->Text = L"Deform mode";
+        // 
+        // m_numbox_cpsize
+        // 
+        this->m_numbox_cpsize->Font = (gcnew System::Drawing::Font(L"MS UI Gothic", 11.5F));
+        this->m_numbox_cpsize->Location = System::Drawing::Point(73, 126);
+        this->m_numbox_cpsize->Minimum = System::Decimal(gcnew cli::array< System::Int32 >(4) { 1, 0, 0, 0 });
+        this->m_numbox_cpsize->Name = L"m_numbox_cpsize";
+        this->m_numbox_cpsize->Size = System::Drawing::Size(57, 23);
+        this->m_numbox_cpsize->TabIndex = 24;
+        this->m_numbox_cpsize->TextAlign = System::Windows::Forms::HorizontalAlignment::Right;
+        this->m_numbox_cpsize->Value = System::Decimal(gcnew cli::array< System::Int32 >(4) { 10, 0, 0, 0 });
+        this->m_numbox_cpsize->ValueChanged += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_numbox_cpsize_ValueChanged);
+        // 
+        // label4
+        // 
+        this->label4->AutoSize = true;
+        this->label4->Location = System::Drawing::Point(21, 131);
+        this->label4->Name = L"label4";
+        this->label4->Size = System::Drawing::Size(46, 12);
+        this->label4->TabIndex = 25;
+        this->label4->Text = L"CP size:";
+        // 
+        // m_checkbox_showonlyselectedstroke
+        // 
+        this->m_checkbox_showonlyselectedstroke->AutoSize = true;
+        this->m_checkbox_showonlyselectedstroke->Font = (gcnew System::Drawing::Font(L"MS UI Gothic", 8));
+        this->m_checkbox_showonlyselectedstroke->Location = System::Drawing::Point(9, 146);
+        this->m_checkbox_showonlyselectedstroke->Name = L"m_checkbox_showonlyselectedstroke";
+        this->m_checkbox_showonlyselectedstroke->Size = System::Drawing::Size(148, 15);
+        this->m_checkbox_showonlyselectedstroke->TabIndex = 26;
+        this->m_checkbox_showonlyselectedstroke->Text = L"Show only selected stroke";
+        this->m_checkbox_showonlyselectedstroke->UseVisualStyleBackColor = true;
+        this->m_checkbox_showonlyselectedstroke->CheckedChanged += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_checkbox_showonlyselectedstroke_CheckedChanged);
+        // 
+        // m_btn_copycagetoallframes
+        // 
+        this->m_btn_copycagetoallframes->Location = System::Drawing::Point(14, 40);
+        this->m_btn_copycagetoallframes->Name = L"m_btn_copycagetoallframes";
+        this->m_btn_copycagetoallframes->Size = System::Drawing::Size(136, 23);
+        this->m_btn_copycagetoallframes->TabIndex = 27;
+        this->m_btn_copycagetoallframes->Text = L"Copy cage to all frames";
+        this->m_btn_copycagetoallframes->UseVisualStyleBackColor = true;
+        this->m_btn_copycagetoallframes->Click += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_btn_copycagetoallframes_Click);
+        // 
+        // groupBox3
+        // 
+        this->groupBox3->Controls->Add(this->label6);
+        this->groupBox3->Controls->Add(this->label5);
+        this->groupBox3->Controls->Add(this->m_btn_deform);
+        this->groupBox3->Controls->Add(this->m_btn_copyfromprevframe);
+        this->groupBox3->Controls->Add(this->m_checkbox_showonlyselectedstroke);
+        this->groupBox3->Controls->Add(this->m_btn_sharestroke);
+        this->groupBox3->Controls->Add(this->m_btn_flipnormal);
+        this->groupBox3->Controls->Add(this->m_textbox_gamma);
+        this->groupBox3->Controls->Add(this->m_textbox_alpha);
+        this->groupBox3->Controls->Add(this->m_textbox_beta);
+        this->groupBox3->Controls->Add(this->label3);
+        this->groupBox3->Controls->Add(this->label2);
+        this->groupBox3->Controls->Add(this->label1);
+        this->groupBox3->Location = System::Drawing::Point(14, 162);
+        this->groupBox3->Name = L"groupBox3";
+        this->groupBox3->Size = System::Drawing::Size(252, 252);
+        this->groupBox3->TabIndex = 28;
+        this->groupBox3->TabStop = false;
+        this->groupBox3->Text = L"Stroke ＆ Deformation";
+        // 
+        // label6
+        // 
+        this->label6->AutoSize = true;
+        this->label6->Font = (gcnew System::Drawing::Font(L"ＭＳ ゴシック", 9, System::Drawing::FontStyle::Regular, System::Drawing::GraphicsUnit::Point,
+            static_cast<System::Byte>(128)));
+        this->label6->Location = System::Drawing::Point(7, 213);
+        this->label6->Name = L"label6";
+        this->label6->Size = System::Drawing::Size(179, 36);
+        this->label6->TabIndex = 29;
+        this->label6->Text = L"Shift + 左 click - 制御点追加\r\nShift + 左 drag - 制御点移動 \r\nShift + 右 down - 制御点削除\r\n";
+        // 
+        // label5
+        // 
+        this->label5->AutoSize = true;
+        this->label5->Font = (gcnew System::Drawing::Font(L"ＭＳ ゴシック", 9, System::Drawing::FontStyle::Regular, System::Drawing::GraphicsUnit::Point,
+            static_cast<System::Byte>(128)));
+        this->label5->Location = System::Drawing::Point(7, 168);
+        this->label5->Name = L"label5";
+        this->label5->Size = System::Drawing::Size(137, 36);
+        this->label5->TabIndex = 29;
+        this->label5->Text = L"　 赤: 選択中のcurve\r\n　 黄: 未選択のcurve\r\n緑/青: all frame curve";
+        // 
+        // m_btn_finish_segmentation
+        // 
+        this->m_btn_finish_segmentation->Font = (gcnew System::Drawing::Font(L"MS UI Gothic", 11.25F, System::Drawing::FontStyle::Bold, System::Drawing::GraphicsUnit::Point,
+            static_cast<System::Byte>(128)));
+        this->m_btn_finish_segmentation->Location = System::Drawing::Point(14, 473);
+        this->m_btn_finish_segmentation->Margin = System::Windows::Forms::Padding(2);
+        this->m_btn_finish_segmentation->Name = L"m_btn_finish_segmentation";
+        this->m_btn_finish_segmentation->Size = System::Drawing::Size(191, 32);
+        this->m_btn_finish_segmentation->TabIndex = 29;
+        this->m_btn_finish_segmentation->Text = L"Finish And Store ROI";
+        this->m_btn_finish_segmentation->UseVisualStyleBackColor = true;
+        this->m_btn_finish_segmentation->Click += gcnew System::EventHandler(this, &FormSegStrokeFfd::m_btn_finish_segmentation_Click);
+        // 
+        // FormSegStrokeFfd
+        // 
+        this->AutoScaleDimensions = System::Drawing::SizeF(6, 12);
+        this->AutoScaleMode = System::Windows::Forms::AutoScaleMode::Font;
+        this->ClientSize = System::Drawing::Size(278, 507);
+        this->Controls->Add(this->m_btn_finish_segmentation);
+        this->Controls->Add(this->groupBox3);
+        this->Controls->Add(this->m_btn_copycagetoallframes);
+        this->Controls->Add(this->label4);
+        this->Controls->Add(this->m_numbox_cpsize);
+        this->Controls->Add(this->groupBox2);
+        this->Controls->Add(this->m_btn_savestate);
+        this->Controls->Add(this->groupBox1);
+        this->Controls->Add(this->m_btn_loadstate);
+        this->Controls->Add(this->m_btn_undo);
+        this->Controls->Add(this->m_btn_savemeshandcage);
+        this->Controls->Add(this->m_btn_loadmeshandcage);
+        this->Name = L"FormSegStrokeFfd";
+        this->Text = L"FormSegStrokeFfd";
+        this->Load += gcnew System::EventHandler(this, &FormSegStrokeFfd::FormSegStrokeFfd_Load);
+        this->groupBox1->ResumeLayout(false);
+        this->groupBox1->PerformLayout();
+        this->groupBox2->ResumeLayout(false);
+        this->groupBox2->PerformLayout();
+        (cli::safe_cast<System::ComponentModel::ISupportInitialize^>(this->m_numbox_cpsize))->EndInit();
+        this->groupBox3->ResumeLayout(false);
+        this->groupBox3->PerformLayout();
+        this->ResumeLayout(false);
+        this->PerformLayout();
 
     }
 #pragma endregion

--- a/RoiPainter4D/RoiPainter4D/Mode/ModeRefCurveDeform.cpp
+++ b/RoiPainter4D/RoiPainter4D/Mode/ModeRefCurveDeform.cpp
@@ -149,6 +149,15 @@ void ModeRefCurveDeform::LBtnDown(const EVec2i& p, OglForCLI* ogl)
       CRSSEC_ID crssec_id = PickCrssec(ray_pos, ray_dir, pos);
       if (crssec_id != CRSSEC_NON)
       {
+        //最近傍のmesh法線を取得
+        EVec3f mesh_normal(0.0f, 0.0f, 0.0f);
+        if (frame_idx >= 0 && frame_idx < m_meshes_def.size() && m_meshes_def[frame_idx].m_vSize > 0)
+        {
+          const TMesh& mesh = m_meshes_def[frame_idx];
+          int nearest_vertex_idx = mesh.GetNearestVertexIdx(pos);
+          if (nearest_vertex_idx >= 0) mesh_normal = mesh.m_vNorms[nearest_vertex_idx];
+        }
+
         if( !m_select_info.selected)
         {
           float crssec_pos = crssec_id == CRSSEC_XY ? pos[2] :
@@ -160,7 +169,7 @@ void ModeRefCurveDeform::LBtnDown(const EVec2i& p, OglForCLI* ogl)
         else if (m_select_info.selected && !m_select_info.is_shared)
         {
           int cpidx;
-          if( m_curves[frame_idx][m_select_info.curve_idx].AddCP(pos, cpidx) ) 
+          if( m_curves[frame_idx][m_select_info.curve_idx].AddCP(pos, cpidx, mesh_normal) ) 
             m_select_info.cp_idx = cpidx;
         }
       }

--- a/RoiPainter4D/RoiPainter4D/Mode/ModeRefCurveDeform.cpp
+++ b/RoiPainter4D/RoiPainter4D/Mode/ModeRefCurveDeform.cpp
@@ -169,8 +169,9 @@ void ModeRefCurveDeform::LBtnDown(const EVec2i& p, OglForCLI* ogl)
         else if (m_select_info.selected && !m_select_info.is_shared)
         {
           int cpidx;
-          if( m_curves[frame_idx][m_select_info.curve_idx].AddCP(pos, cpidx, mesh_normal) ) 
-            m_select_info.cp_idx = cpidx;
+          if(m_curves[frame_idx][m_select_info.curve_idx].AddCP(pos, cpidx)) m_select_info.cp_idx = cpidx;
+          //2点目が追加されたら外側を向くように法線計算
+          if(m_curves[frame_idx][m_select_info.curve_idx].GetNumCPs() == 2) m_curves[frame_idx][m_select_info.curve_idx].AlignNormalWithMesh(mesh_normal);
         }
       }
       else

--- a/RoiPainter4D/RoiPainter4D/Mode/ModeSegStrokeFfd.cpp
+++ b/RoiPainter4D/RoiPainter4D/Mode/ModeSegStrokeFfd.cpp
@@ -187,6 +187,7 @@ void ModeSegStrokeFfd::LBtnDown(const EVec2i& p, OglForCLI* ogl)
       }
       else if(crssec_id != CRSSEC_NON)
       {
+        //最近傍のmesh法線を取得
         EVec3f mesh_normal(0.0f, 0.0f, 0.0f);
         if (m_meshseq.IsInitialized())
         {
@@ -207,8 +208,9 @@ void ModeSegStrokeFfd::LBtnDown(const EVec2i& p, OglForCLI* ogl)
         else if (m_select_info.selected && !m_select_info.is_shared)
         {
           int cpidx;
-          if (m_curves[frame_idx][m_select_info.curve_idx].AddCP(pos, cpidx, mesh_normal))
-            m_select_info.cp_idx = cpidx;
+          if (m_curves[frame_idx][m_select_info.curve_idx].AddCP(pos, cpidx)) m_select_info.cp_idx = cpidx;
+          //2点目が追加されたら外側を向くように法線計算
+          if (m_curves[frame_idx][m_select_info.curve_idx].GetNumCPs() == 2) m_curves[frame_idx][m_select_info.curve_idx].AlignNormalWithMesh(mesh_normal);
         }
       }
       else

--- a/RoiPainter4D/RoiPainter4D/Mode/ModeSegStrokeFfd.cpp
+++ b/RoiPainter4D/RoiPainter4D/Mode/ModeSegStrokeFfd.cpp
@@ -907,6 +907,25 @@ void ModeSegStrokeFfd::MakeSelectedStroke_Shared()
 
 
 
+void ModeSegStrokeFfd::FlipSelectedStrokeNormalSide()
+{
+  const int frame_idx = formVisParam_getframeI();
+  const int cidx = m_select_info.curve_idx;
+
+  if (m_select_info.selected && m_select_info.is_shared && cidx != -1)
+  {
+    m_shared_curves[cidx].FlipNormal();
+  }
+  if (m_select_info.selected && !m_select_info.is_shared && cidx != -1)
+  {
+    m_curves[frame_idx][cidx].FlipNormal();
+  }
+  formMain_RedrawMainPanel();
+  formMain_ActivateMainForm();
+}
+
+
+
 void ModeSegStrokeFfd::MakeSelectedStroke_Unshared()
 {
   const int frame_idx = formVisParam_getframeI();

--- a/RoiPainter4D/RoiPainter4D/Mode/ModeSegStrokeFfd.cpp
+++ b/RoiPainter4D/RoiPainter4D/Mode/ModeSegStrokeFfd.cpp
@@ -187,6 +187,14 @@ void ModeSegStrokeFfd::LBtnDown(const EVec2i& p, OglForCLI* ogl)
       }
       else if(crssec_id != CRSSEC_NON)
       {
+        EVec3f mesh_normal(0.0f, 0.0f, 0.0f);
+        if (m_meshseq.IsInitialized())
+        {
+          const TMesh& mesh = m_meshseq.GetMesh(frame_idx);
+          int nearest_vertex_idx = mesh.GetNearestVertexIdx(pos);
+          if (nearest_vertex_idx >= 0) mesh_normal = mesh.m_vNorms[nearest_vertex_idx];
+        }
+
         //picking失敗 & crosec pick成功 - 新curve追加 or 新CP追加
         if (!m_select_info.selected)
         {
@@ -199,7 +207,7 @@ void ModeSegStrokeFfd::LBtnDown(const EVec2i& p, OglForCLI* ogl)
         else if (m_select_info.selected && !m_select_info.is_shared)
         {
           int cpidx;
-          if (m_curves[frame_idx][m_select_info.curve_idx].AddCP(pos, cpidx))
+          if (m_curves[frame_idx][m_select_info.curve_idx].AddCP(pos, cpidx, mesh_normal))
             m_select_info.cp_idx = cpidx;
         }
       }

--- a/RoiPainter4D/RoiPainter4D/Mode/ModeSegStrokeFfd.h
+++ b/RoiPainter4D/RoiPainter4D/Mode/ModeSegStrokeFfd.h
@@ -95,6 +95,7 @@ public:
   void CopyFromPrevFrame();
   void CopyCageToAllFrames();
   void MakeSelectedStroke_Shared();
+  void FlipSelectedStrokeNormalSide();
   void MakeSelectedStroke_Unshared();
 
   void ClearSelectionInfo();


### PR DESCRIPTION
・SegStrokeFFDモードにflip normalボタンを追加
・RefCurveDefromモードのUI修正
・TMesh::GetNearestVertexIdxを利用し、クリック座標から最寄りのメッシュ頂点法線を取得する処理を実装 (ModeRefCurveDeform::LBtnDown, ModeSegStrokeFfd::LBtnDown)
・ストロークの2点目追加時に、法線とメッシュ法線の内積を比較し、外側を向くように自動反転させる処理を追加(ModeRefCurveDeform::LBtnDown, ModeSegStrokeFfd::LBtnDown,PlanarCurve::AlignNormalWithMesh)